### PR TITLE
Add CeloPrecompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
+ "lazy_static",
  "op-revm",
  "revm",
  "rstest",

--- a/crates/celo-revm/Cargo.toml
+++ b/crates/celo-revm/Cargo.toml
@@ -32,6 +32,7 @@ op-revm.workspace = true
 
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
+lazy_static.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/celo-revm/src/chain_info.rs
+++ b/crates/celo-revm/src/chain_info.rs
@@ -1,0 +1,47 @@
+use lazy_static::lazy_static;
+use revm::primitives::{Address, HashMap, address};
+
+pub const CELO_MAINNET_CHAIN_ID: u64 = 42220;
+pub const CELO_ALFAJORES_CHAIN_ID: u64 = 44787;
+pub const CELO_BAKLAVA_CHAIN_ID: u64 = 62320;
+
+pub struct CeloAddresses {
+    pub celo_token: Address,
+}
+
+// Static map of chain IDs to their addresses
+lazy_static! {
+    pub static ref CELO_ADDRESSES: HashMap<u64, CeloAddresses> = {
+        let mut m = HashMap::new();
+
+        m.insert(
+            CELO_MAINNET_CHAIN_ID,
+            CeloAddresses {
+                celo_token: address!("0x471ece3750da237f93b8e339c536989b8978a438"),
+            },
+        );
+
+        m.insert(
+            CELO_ALFAJORES_CHAIN_ID,
+            CeloAddresses {
+                celo_token: address!("0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"),
+            },
+        );
+
+        m.insert(
+            CELO_BAKLAVA_CHAIN_ID,
+            CeloAddresses {
+                celo_token: address!("0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"),
+            },
+        );
+
+        m
+    };
+}
+
+/// Returns the addresses for the given chain ID, or Mainnet addresses if not found.
+pub fn get_addresses(chain_id: u64) -> &'static CeloAddresses {
+    CELO_ADDRESSES
+        .get(&chain_id)
+        .unwrap_or(&CELO_ADDRESSES[&CELO_MAINNET_CHAIN_ID])
+}

--- a/crates/celo-revm/src/lib.rs
+++ b/crates/celo-revm/src/lib.rs
@@ -5,6 +5,9 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc as std;
 
+pub mod chain_info;
 pub mod evm;
+pub mod precompiles;
+pub mod transfer;
 
 pub use evm::CeloEvm;

--- a/crates/celo-revm/src/precompiles.rs
+++ b/crates/celo-revm/src/precompiles.rs
@@ -1,0 +1,248 @@
+use crate::transfer::{TRANSFER_ADDRESS, transfer_run};
+use core::iter;
+use op_revm::{OpSpecId, precompiles::OpPrecompiles};
+use revm::{
+    context::Cfg,
+    context_interface::ContextTr,
+    handler::PrecompileProvider,
+    interpreter::{InputsImpl, InterpreterResult},
+    primitives::Address,
+};
+use std::boxed::Box;
+use std::string::String;
+
+// Celo precompile provider
+#[derive(Debug, Clone)]
+pub struct CeloPrecompiles {
+    op_precompiles: OpPrecompiles,
+}
+
+impl CeloPrecompiles {
+    /// Create a new precompile provider with the given OpSpec.
+    #[inline]
+    pub fn new_with_spec(spec: OpSpecId) -> Self {
+        Self {
+            op_precompiles: OpPrecompiles::new_with_spec(spec),
+        }
+    }
+}
+
+impl<CTX> PrecompileProvider<CTX> for CeloPrecompiles
+where
+    CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
+{
+    type Output = InterpreterResult;
+
+    #[inline]
+    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
+        <OpPrecompiles as PrecompileProvider<CTX>>::set_spec(&mut self.op_precompiles, spec)
+    }
+
+    #[inline]
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        address: &Address,
+        inputs: &InputsImpl,
+        is_static: bool,
+        gas_limit: u64,
+    ) -> Result<Option<Self::Output>, String> {
+        if *address == TRANSFER_ADDRESS {
+            transfer_run(context, inputs, gas_limit)
+        } else {
+            self.op_precompiles
+                .run(context, address, inputs, is_static, gas_limit)
+        }
+    }
+
+    #[inline]
+    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+        let op_iter =
+            <OpPrecompiles as PrecompileProvider<CTX>>::warm_addresses(&self.op_precompiles);
+        let transfer_iter = iter::once(TRANSFER_ADDRESS);
+        Box::new(op_iter.chain(transfer_iter))
+    }
+
+    #[inline]
+    fn contains(&self, address: &Address) -> bool {
+        *address == TRANSFER_ADDRESS
+            || <OpPrecompiles as PrecompileProvider<CTX>>::contains(&self.op_precompiles, address)
+    }
+}
+
+impl Default for CeloPrecompiles {
+    fn default() -> Self {
+        Self::new_with_spec(OpSpecId::ISTHMUS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        chain_info::{CELO_MAINNET_CHAIN_ID, get_addresses},
+        transfer::TRANSFER_GAS_COST,
+    };
+    use op_revm::{DefaultOp, OpContext};
+    use revm::{
+        Context,
+        context::{JournalOutput, JournalTr},
+        database::{EmptyDB, in_memory_db::InMemoryDB},
+        interpreter::InstructionResult,
+        primitives::{Bytes, U256},
+        state::AccountInfo,
+    };
+
+    #[test]
+    fn test_celo_precompiles_count() {
+        let celo_precompiles = CeloPrecompiles::default();
+        let op_precompiles = OpPrecompiles::default();
+
+        let celo_count =
+            <CeloPrecompiles as PrecompileProvider<OpContext<EmptyDB>>>::warm_addresses(
+                &celo_precompiles,
+            )
+            .count();
+        let op_count = <OpPrecompiles as PrecompileProvider<OpContext<EmptyDB>>>::warm_addresses(
+            &op_precompiles,
+        )
+        .count();
+
+        assert_eq!(celo_count, op_count + 1);
+    }
+
+    #[test]
+    fn test_transfer() {
+        let mut precompiles = CeloPrecompiles::default();
+
+        let from = Address::with_last_byte(1);
+        let to = Address::with_last_byte(2);
+        let value = 10;
+        let mut input_vec = vec![0u8; 96];
+        input_vec[31] = 1;
+        input_vec[63] = 2;
+        input_vec[95] = value;
+        let input = Bytes::from(input_vec);
+
+        let inputs = InputsImpl {
+            target_address: TRANSFER_ADDRESS,
+            caller_address: from,
+            input,
+            call_value: U256::from(value),
+        };
+
+        let initial_balance = 100;
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            from,
+            AccountInfo {
+                balance: U256::from(initial_balance),
+                ..Default::default()
+            },
+        );
+
+        // Test calling with valid parameters
+        let mut ctx = Context::op()
+            .modify_tx_chained(|tx| {
+                tx.base.caller = get_addresses(CELO_MAINNET_CHAIN_ID).celo_token;
+            })
+            .modify_cfg_chained(|cfg| cfg.chain_id = CELO_MAINNET_CHAIN_ID)
+            .with_db(db);
+
+        let res = precompiles.run(
+            &mut ctx,
+            &TRANSFER_ADDRESS,
+            &inputs,
+            false,
+            TRANSFER_GAS_COST,
+        );
+        assert!(res.is_ok());
+
+        let JournalOutput { state, .. } = ctx.journal().finalize();
+        let from_account = state.get(&from).unwrap();
+        let to_account = state.get(&to).unwrap();
+        assert_eq!(
+            from_account.info.balance,
+            U256::from(initial_balance - value)
+        );
+        assert_eq!(to_account.info.balance, U256::from(value));
+
+        // Test calling with too little gas
+        let res = precompiles.run(
+            &mut ctx,
+            &TRANSFER_ADDRESS,
+            &inputs,
+            false,
+            TRANSFER_GAS_COST - 1_000,
+        );
+        assert!(matches!(
+            res,
+            Ok(Some(InterpreterResult {
+                result: InstructionResult::PrecompileOOG,
+                ..
+            }))
+        ));
+
+        // Test calling with too short input
+        let short_input = Bytes::from(vec![0; 63]);
+        let bad_input = InputsImpl {
+            input: short_input,
+            ..inputs
+        };
+        let res = precompiles.run(
+            &mut ctx,
+            &TRANSFER_ADDRESS,
+            &bad_input,
+            false,
+            TRANSFER_GAS_COST,
+        );
+        assert!(matches!(
+            res,
+            Ok(Some(InterpreterResult {
+                result: InstructionResult::PrecompileError,
+                ..
+            }))
+        ));
+
+        // Test calling from the wrong address
+        ctx.modify_tx(|tx| {
+            tx.base.caller = from;
+        });
+        let res = precompiles.run(
+            &mut ctx,
+            &TRANSFER_ADDRESS,
+            &inputs,
+            false,
+            TRANSFER_GAS_COST,
+        );
+        assert!(matches!(
+            res,
+            Ok(Some(InterpreterResult {
+                result: InstructionResult::PrecompileError,
+                ..
+            }))
+        ));
+
+        // Test calling with value bigger than balance
+        let mut input_vec = vec![0u8; 96];
+        input_vec[31] = 1;
+        input_vec[63] = 2;
+        input_vec[95] = initial_balance + 10;
+        let input = Bytes::from(input_vec);
+        let big_value_input = InputsImpl { input, ..inputs };
+        let res = precompiles.run(
+            &mut ctx,
+            &TRANSFER_ADDRESS,
+            &big_value_input,
+            false,
+            TRANSFER_GAS_COST,
+        );
+        assert!(matches!(
+            res,
+            Ok(Some(InterpreterResult {
+                result: InstructionResult::PrecompileError,
+                ..
+            }))
+        ));
+    }
+}

--- a/crates/celo-revm/src/transfer.rs
+++ b/crates/celo-revm/src/transfer.rs
@@ -1,0 +1,89 @@
+//! [`transfer` precompile](https://specs.celo.org/token_duality.html#the-transfer-precompile)
+//! For more details check [`transfer_run`] function.
+
+use crate::chain_info;
+use op_revm::OpSpecId;
+use revm::{
+    context::{Cfg, ContextTr, JournalTr, Transaction},
+    interpreter::{Gas, InputsImpl, InstructionResult, InterpreterResult},
+    precompile::{PrecompileError, PrecompileOutput, PrecompileResult, u64_to_address},
+    primitives::{Address, Bytes, U256},
+};
+
+/// Address of the `transfer` precompile.
+pub const TRANSFER_ADDRESS: Address = u64_to_address(0xff - 2);
+
+/// Gas cost of the `transfer` precompile.
+pub const TRANSFER_GAS_COST: u64 = 9_000;
+
+/// Run `transfer` precompile.
+pub fn transfer_run<CTX>(
+    context: &mut CTX,
+    inputs: &InputsImpl,
+    gas_limit: u64,
+) -> Result<Option<InterpreterResult>, String>
+where
+    CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
+{
+    let mut result = InterpreterResult {
+        result: InstructionResult::Return,
+        gas: Gas::new(gas_limit),
+        output: Bytes::new(),
+    };
+
+    match run(context, &inputs.input, gas_limit) {
+        Ok(output) => {
+            let underflow = result.gas.record_cost(output.gas_used);
+            assert!(underflow, "Gas underflow is not possible");
+            result.result = InstructionResult::Return;
+            result.output = output.bytes;
+        }
+        Err(PrecompileError::Fatal(e)) => return Err(e),
+        Err(e) => {
+            result.result = if e.is_oog() {
+                InstructionResult::PrecompileOOG
+            } else {
+                InstructionResult::PrecompileError
+            };
+        }
+    }
+    Ok(Some(result))
+}
+
+fn run<CTX>(context: &mut CTX, input: &Bytes, gas_limit: u64) -> PrecompileResult
+where
+    CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
+{
+    if gas_limit < TRANSFER_GAS_COST {
+        return Err(PrecompileError::OutOfGas);
+    }
+
+    if context.tx().caller() != chain_info::get_addresses(context.cfg().chain_id()).celo_token {
+        return Err(PrecompileError::Other(
+            "invalid caller for transfer precompile".to_string(),
+        ));
+    }
+
+    if input.len() != 96 {
+        return Err(PrecompileError::Other("invalid input length".to_string()));
+    }
+
+    let from = Address::from_slice(&input[12..32]);
+    let to = Address::from_slice(&input[44..64]);
+    let value = U256::from_be_slice(&input[64..96]);
+
+    let result = context.journal().transfer(from, to, value);
+    if let Ok(Some(transfer_err)) = result {
+        return Err(PrecompileError::Other(format!(
+            "transfer error occurred: {:?}",
+            transfer_err
+        )));
+    } else if let Err(db_err) = result {
+        return Err(PrecompileError::Other(format!(
+            "database error occurred: {:?}",
+            db_err
+        )));
+    }
+
+    Ok(PrecompileOutput::new(TRANSFER_GAS_COST, Bytes::new()))
+}


### PR DESCRIPTION
Added `CeloPrecompiles` which contains `transfer` precompile. Since `transfer` requires `context` information such as tx caller, chain_id, ... , so it cannot be integrated into `OpPrecompiles.inner.precompiles`. Instead just wrapped all functions implemented in `OpPrecompiles` to include `transfer`.