### PR TITLE
Fix "arbitrary" dep in tests

### DIFF
--- a/crates/celo-revm/Cargo.toml
+++ b/crates/celo-revm/Cargo.toml
@@ -52,6 +52,8 @@ rstest.workspace = true
 #serde_json = { workspace = true, features = ["alloc"] }
 rand = { version = "0.8", features = ["std"] }
 bincode = "1.3"
+arbitrary = { workspace = true, features = ["derive"] }
+alloy-eips = { workspace = true, features = ["arbitrary"] }
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]


### PR DESCRIPTION
Without this, these deps are missing when running `cargo test`. I didn't notice before because I usually ran `cargo test --all-features`.

Now, this is handled similar to how it is done in alloy. I don't know if we really need to have all these feature flags, but since we are mostly imitating other people's code at the moment, I thought it makes sense to also keep those.