### PR TITLE
Bump kona to kona-client/v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,6 @@ dependencies = [
  "kona-executor",
  "kona-genesis",
  "kona-protocol",
- "kona-rpc",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "spin 0.10.0",
@@ -1793,7 +1792,6 @@ dependencies = [
  "kona-protocol",
  "kona-providers-alloy",
  "kona-registry",
- "kona-rpc",
  "kona-std-fpvm",
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
@@ -1833,7 +1831,6 @@ dependencies = [
  "kona-preimage",
  "kona-protocol",
  "kona-registry",
- "kona-rpc",
  "lazy_static",
  "lru 0.14.0",
  "op-alloy-consensus",
@@ -3341,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "clap",
  "libc",
@@ -3352,8 +3349,8 @@ dependencies = [
 
 [[package]]
 name = "kona-client"
-version = "1.0.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+version = "1.0.1"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3392,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3403,7 +3400,7 @@ dependencies = [
  "kona-genesis",
  "kona-hardforks",
  "kona-protocol",
- "kona-rpc",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "thiserror 2.0.12",
  "tracing",
@@ -3412,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -3423,7 +3420,6 @@ dependencies = [
  "kona-executor",
  "kona-genesis",
  "kona-protocol",
- "kona-rpc",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "spin 0.10.0",
@@ -3434,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3471,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3491,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-eips 0.15.11",
  "alloy-primitives",
@@ -3501,8 +3497,8 @@ dependencies = [
 
 [[package]]
 name = "kona-host"
-version = "1.0.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+version = "1.0.1"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3533,7 +3529,6 @@ dependencies = [
  "kona-protocol",
  "kona-providers-alloy",
  "kona-registry",
- "kona-rpc",
  "kona-std-fpvm",
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
@@ -3551,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3572,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3584,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -3596,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3616,7 +3611,6 @@ dependencies = [
  "kona-preimage",
  "kona-protocol",
  "kona-registry",
- "kona-rpc",
  "lazy_static",
  "lru 0.14.0",
  "op-alloy-consensus",
@@ -3633,10 +3627,11 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
+ "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -3652,6 +3647,8 @@ dependencies = [
  "kona-registry",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
+ "op-revm",
+ "revm",
  "serde",
  "serde_json",
  "spin 0.10.0",
@@ -3662,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3680,6 +3677,7 @@ dependencies = [
  "miniz_oxide",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
  "rand 0.9.1",
  "serde",
  "spin 0.10.0",
@@ -3692,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.15.11",
@@ -3709,7 +3707,6 @@ dependencies = [
  "kona-derive",
  "kona-genesis",
  "kona-protocol",
- "kona-rpc",
  "lru 0.14.0",
  "op-alloy-consensus",
  "op-alloy-network",
@@ -3722,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.3.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3734,23 +3731,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "kona-rpc"
-version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
-dependencies = [
- "alloy-eips 0.15.11",
- "alloy-primitives",
- "derive_more",
- "kona-protocol",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "kona-serde"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -3760,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "async-trait",
  "buddy_system_allocator",
@@ -3773,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.0#a1172e46a743c63c9f0a0f13a444144e38d29355"
+source = "git+https://github.com/op-rs/kona?tag=kona-client%2Fv1.0.1#9d1ace6bd9a8bfac650f3323a3f1b3c91db46135"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,71 +77,71 @@ celo-proof = { version = "0.1.0", path = "crates/kona/proof", default-features =
 celo-protocol = { version = "0.1.0", path = "crates/kona/protocol", default-features = false }
 
 # Binaries
-kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
+kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # Protocol
-kona-comp = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-interop = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-protocol = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-hardforks = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
+kona-comp = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-interop = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-protocol = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-hardforks = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # Node
-kona-p2p = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-rpc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-engine = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-node-service = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
+kona-p2p = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-rpc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-engine = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-node-service = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # Providers
-kona-providers-alloy = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
+kona-providers-alloy = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # Proof
-kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-std-fpvm = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-std-fpvm-proc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-proof-interop = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
+kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-std-fpvm = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-std-fpvm-proc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-proof-interop = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # Utilities
-kona-cli = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
-kona-serde = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.0", default-features = false }
+kona-cli = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
+kona-serde = { git = "https://github.com/op-rs/kona", tag = "kona-client/v1.0.1", default-features = false }
 
 # Alloy
 alloy-rlp = { version = "0.3.11", default-features = false }
 alloy-trie = { version = "0.8.0", default-features = false }
 alloy-chains = { version = "0.2", default-features = false }
-alloy-eips = { version = "0.15.6", default-features = false }
-alloy-serde = { version = "0.15.6", default-features = false }
-alloy-network = { version = "0.15.6", default-features = false }
-alloy-provider = { version = "0.15.6", default-features = false }
-alloy-sol-types = { version = "1.0.0", default-features = false }
-alloy-consensus = { version = "0.15.6", default-features = false }
-alloy-transport = { version = "0.15.6", default-features = false }
-alloy-rpc-types = { version = "0.15.6", default-features = false }
-alloy-rpc-client = { version = "0.15.6", default-features = false }
-alloy-primitives = { version = "1.0.0", default-features = false }
-alloy-node-bindings = { version = "0.15.6", default-features = false }
-alloy-rpc-types-eth = { version = "0.15.6", default-features = false }
-alloy-transport-http = { version = "0.15.6", default-features = false }
-alloy-rpc-types-engine = { version = "0.15.6", default-features = false }
-alloy-rpc-types-beacon = { version = "0.15.6", default-features = false }
-alloy-network-primitives = { version = "0.15.6", default-features = false }
+alloy-eips = { version = "0.15.8", default-features = false }
+alloy-serde = { version = "0.15.8", default-features = false }
+alloy-network = { version = "0.15.8", default-features = false }
+alloy-provider = { version = "0.15.8", default-features = false }
+alloy-sol-types = { version = "1.1.0", default-features = false }
+alloy-consensus = { version = "0.15.8", default-features = false }
+alloy-transport = { version = "0.15.8", default-features = false }
+alloy-rpc-types = { version = "0.15.8", default-features = false }
+alloy-rpc-client = { version = "0.15.8", default-features = false }
+alloy-primitives = { version = "1.1.0", default-features = false }
+alloy-node-bindings = { version = "0.15.8", default-features = false }
+alloy-rpc-types-eth = { version = "0.15.8", default-features = false }
+alloy-transport-http = { version = "0.15.8", default-features = false }
+alloy-rpc-types-engine = { version = "0.15.8", default-features = false }
+alloy-rpc-types-beacon = { version = "0.15.8", default-features = false }
+alloy-network-primitives = { version = "0.15.8", default-features = false }
 alloy-hardforks = { version = "0.2.0", default-features = false }
 alloy-signer = { version = "0.15.6", default-features = false }
 
 # OP Alloy
-op-alloy-network = { version = "0.15.1", default-features = false }
-op-alloy-provider = { version = "0.15.1", default-features = false }
-op-alloy-consensus = { version = "0.15.1", default-features = false }
-op-alloy-rpc-types = { version = "0.15.1", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.15.1", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.15.1", default-features = false }
+op-alloy-network = { version = "0.15.2", default-features = false }
+op-alloy-provider = { version = "0.15.2", default-features = false }
+op-alloy-consensus = { version = "0.15.2", default-features = false }
+op-alloy-rpc-types = { version = "0.15.2", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.15.2", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.15.2", default-features = false }
 alloy-op-hardforks = { version = "0.2.0", default-features = false }
 
 # Execution
@@ -201,6 +201,8 @@ openssl = "0.10.72"
 tracing-loki = "0.2.6"
 tracing-subscriber = "0.3.19"
 tracing = { version = "0.1.41", default-features = false }
+
+# Metrics
 metrics-exporter-prometheus = { version = "0.17.0", default-features = false }
 
 # Testing
@@ -221,5 +223,5 @@ serde_with = { version = "3", default-features = false, features = ["macros"] }
 rocksdb = { version = "0.23.0", default-features = false }
 
 # Cryptography
-secp256k1 = { version = "0.30.0", default-features = false }
 ark-ff = { version = "0.5.0", default-features = false }
+secp256k1 = { version = "0.31.0", default-features = false }

--- a/bin/client/src/client.rs
+++ b/bin/client/src/client.rs
@@ -13,7 +13,6 @@
 extern crate alloc;
 
 use alloc::string::String;
-use alloy_celo_evm::CeloEvmFactory;
 use kona_preimage::{HintWriter, OracleReader};
 use kona_std_fpvm::{FileChannel, FileDescriptor};
 use kona_std_fpvm_proc::client_entry;
@@ -43,9 +42,5 @@ fn main() -> Result<(), String> {
             .expect("Failed to set tracing subscriber");
     }
 
-    kona_proof::block_on(celo_client::single::run(
-        ORACLE_READER,
-        HINT_WRITER,
-        CeloEvmFactory::default(),
-    ))
+    kona_proof::block_on(celo_client::single::run(ORACLE_READER, HINT_WRITER))
 }

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -40,7 +40,6 @@ kona-genesis = { workspace = true, features = ["std", "serde"] }
 
 # Services
 kona-cli.workspace = true
-kona-rpc.workspace = true
 kona-providers-alloy.workspace = true
 
 # Alloy

--- a/bin/host/src/backend/util.rs
+++ b/bin/host/src/backend/util.rs
@@ -11,6 +11,7 @@ use tokio::sync::RwLock;
 
 /// Constructs a merkle patricia trie from the ordered list passed and stores all encoded
 /// intermediate nodes of the trie in the [KeyValueStore].
+#[allow(dead_code)]
 pub(crate) async fn store_ordered_trie<KV: KeyValueStore + ?Sized, T: AsRef<[u8]>>(
     kv: &RwLock<KV>,
     values: &[T],

--- a/bin/host/src/bin/host.rs
+++ b/bin/host/src/bin/host.rs
@@ -48,6 +48,7 @@ pub enum HostMode {
 }
 
 #[tokio::main(flavor = "multi_thread")]
+#[allow(unreachable_code, unused_variables)]
 async fn main() -> Result<()> {
     let cfg = HostCli::parse();
     init_tracing_subscriber(cfg.v, None::<EnvFilter>)?;

--- a/bin/host/src/eth/mod.rs
+++ b/bin/host/src/eth/mod.rs
@@ -1,4 +1,5 @@
 //! Ethereum utilities for the host binary.
 
 mod precompiles;
+#[allow(unused_imports)]
 pub(crate) use precompiles::execute;

--- a/bin/host/src/eth/precompiles.rs
+++ b/bin/host/src/eth/precompiles.rs
@@ -6,6 +6,7 @@ use anyhow::{Result, anyhow};
 use revm::precompile::{self, PrecompileWithAddress};
 
 /// List of precompiles that are accelerated by the host program.
+#[allow(dead_code)]
 pub(crate) const ACCELERATED_PRECOMPILES: &[PrecompileWithAddress] = &[
     precompile::secp256k1::ECRECOVER,          // ecRecover
     precompile::bn128::pair::ISTANBUL,         // ecPairing
@@ -21,6 +22,7 @@ pub(crate) const ACCELERATED_PRECOMPILES: &[PrecompileWithAddress] = &[
 ];
 
 /// Executes an accelerated precompile on [revm].
+#[allow(dead_code)]
 pub(crate) fn execute<T: Into<Bytes>>(address: Address, input: T, gas: u64) -> Result<Vec<u8>> {
     if let Some(precompile) = ACCELERATED_PRECOMPILES
         .iter()

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -1,7 +1,6 @@
 //! This module contains all CLI-specific code for the single chain entrypoint.
 
 use crate::single::CeloSingleChainHintHandler;
-use alloy_celo_evm::CeloEvmFactory;
 use alloy_provider::RootProvider;
 use celo_alloy_network::Celo;
 use clap::Parser;
@@ -103,7 +102,6 @@ impl CeloSingleChainHost {
         let client_task = task::spawn(celo_client::single::run(
             OracleReader::new(preimage.client),
             HintWriter::new(hint.client),
-            CeloEvmFactory::default(),
         ));
 
         let (_, client_result) = tokio::try_join!(server_task, client_task)?;

--- a/crates/kona/driver/Cargo.toml
+++ b/crates/kona/driver/Cargo.toml
@@ -22,7 +22,6 @@ celo-protocol.workspace = true
 # Kona
 kona-derive.workspace = true
 kona-executor.workspace = true
-kona-rpc.workspace = true
 kona-genesis.workspace = true
 kona-protocol.workspace = true
 kona-driver.workspace = true

--- a/crates/kona/driver/src/core.rs
+++ b/crates/kona/driver/src/core.rs
@@ -17,8 +17,7 @@ use kona_derive::{
 };
 use kona_driver::{DriverError, DriverPipeline, DriverResult, PipelineCursor, TipCursor};
 use kona_genesis::RollupConfig;
-use kona_protocol::L2BlockInfo;
-use kona_rpc::OpAttributesWithParent;
+use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
 use spin::RwLock;
 
 /// The Rollup Driver entrypoint.

--- a/crates/kona/driver/src/executor.rs
+++ b/crates/kona/driver/src/executor.rs
@@ -1,15 +1,12 @@
 //! An abstraction for the driver's block executor.
 
-use alloc::{boxed::Box, string::ToString};
+use alloc::boxed::Box;
 use alloy_consensus::{Header, Sealed};
 use alloy_primitives::B256;
 use async_trait::async_trait;
 use celo_alloy_rpc_types_engine::CeloPayloadAttributes;
 use celo_executor::CeloBlockBuildingOutcome;
-use core::{
-    error::Error,
-    fmt::{Debug, Display},
-};
+use core::error::Error;
 
 /// CeloExecutorTr
 ///
@@ -17,7 +14,7 @@ use core::{
 #[async_trait]
 pub trait CeloExecutorTr {
     /// The error type for the CeloExecutorTr.
-    type Error: Error + Debug + Display + ToString;
+    type Error: Error;
 
     /// Waits for the executor to be ready.
     async fn wait_until_ready(&mut self);

--- a/crates/kona/executor/src/builder/assemble.rs
+++ b/crates/kona/executor/src/builder/assemble.rs
@@ -48,8 +48,7 @@ where
             |tx, buf| buf.put_slice(tx.as_ref()),
         )
         .root();
-        let receipts_root =
-            Self::compute_receipts_root(&ex_result.receipts, self.config, timestamp);
+        let receipts_root = compute_receipts_root(&ex_result.receipts, self.config, timestamp);
         let withdrawals_root = if self.config.is_isthmus_active(timestamp) {
             Some(self.message_passer_account(block_env.number)?)
         } else if self.config.is_canyon_active(timestamp) {
@@ -167,37 +166,36 @@ where
                 .storage_root),
         }
     }
+}
 
-    /// Computes the receipts root from the given set of receipts.
-    fn compute_receipts_root(
-        receipts: &[CeloReceiptEnvelope],
-        config: &RollupConfig,
-        timestamp: u64,
-    ) -> B256 {
-        // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
-        // the receipt root calculation does not inclide the deposit nonce in the
-        // receipt encoding. In the Regolith hardfork, we must strip the deposit nonce
-        // from the receipt encoding to match the receipt root calculation.
-        if config.is_regolith_active(timestamp) && !config.is_canyon_active(timestamp) {
-            let receipts = receipts
-                .iter()
-                .cloned()
-                .map(|receipt| match receipt {
-                    CeloReceiptEnvelope::Deposit(mut deposit_receipt) => {
-                        deposit_receipt.receipt.deposit_nonce = None;
-                        CeloReceiptEnvelope::Deposit(deposit_receipt)
-                    }
-                    _ => receipt,
-                })
-                .collect::<Vec<_>>();
-
-            ordered_trie_with_encoder(receipts.as_ref(), |receipt, mut buf| {
-                receipt.encode_2718(&mut buf)
+/// Computes the receipts root from the given set of receipts.
+pub fn compute_receipts_root(
+    receipts: &[CeloReceiptEnvelope],
+    config: &RollupConfig,
+    timestamp: u64,
+) -> B256 {
+    // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
+    // the receipt root calculation does not inclide the deposit nonce in the
+    // receipt encoding. In the Regolith hardfork, we must strip the deposit nonce
+    // from the receipt encoding to match the receipt root calculation.
+    if config.is_regolith_active(timestamp) && !config.is_canyon_active(timestamp) {
+        let receipts = receipts
+            .iter()
+            .cloned()
+            .map(|receipt| match receipt {
+                CeloReceiptEnvelope::Deposit(mut deposit_receipt) => {
+                    deposit_receipt.receipt.deposit_nonce = None;
+                    CeloReceiptEnvelope::Deposit(deposit_receipt)
+                }
+                _ => receipt,
             })
-            .root()
-        } else {
-            ordered_trie_with_encoder(receipts, |receipt, mut buf| receipt.encode_2718(&mut buf))
-                .root()
-        }
+            .collect::<Vec<_>>();
+
+        ordered_trie_with_encoder(receipts.as_ref(), |receipt, mut buf| {
+            receipt.encode_2718(&mut buf)
+        })
+        .root()
+    } else {
+        ordered_trie_with_encoder(receipts, |receipt, mut buf| receipt.encode_2718(&mut buf)).root()
     }
 }

--- a/crates/kona/executor/src/builder/mod.rs
+++ b/crates/kona/executor/src/builder/mod.rs
@@ -4,4 +4,6 @@ mod core;
 pub use core::{CeloBlockBuildingOutcome, CeloStatelessL2Builder};
 
 mod assemble;
+pub use assemble::compute_receipts_root;
+
 mod env;

--- a/crates/kona/executor/src/lib.rs
+++ b/crates/kona/executor/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 extern crate tracing;
 
 mod builder;
-pub use builder::{CeloBlockBuildingOutcome, CeloStatelessL2Builder};
+pub use builder::{CeloBlockBuildingOutcome, CeloStatelessL2Builder, compute_receipts_root};
 
 pub(crate) mod util;
 

--- a/crates/kona/proof/Cargo.toml
+++ b/crates/kona/proof/Cargo.toml
@@ -25,7 +25,6 @@ kona-derive.workspace = true
 kona-driver.workspace = true
 kona-preimage.workspace = true
 kona-executor.workspace = true
-kona-rpc.workspace = true
 kona-protocol.workspace = true
 kona-registry.workspace = true
 kona-genesis = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
Since hokulea has been a bit different from the [old commit](https://github.com/Layr-Labs/hokulea/commit/b10e35c210fed2ec3fd2f07b1dffddae4c41756f) depending on `kona-client/v1.0.0`, I wanted to integrate the latest version of hokulea which depends on `kona-client/v1.0.1`. The new version seems to match with the [links](https://clabsco.slack.com/archives/C07614NNXDH/p1748023708748799) Eigen team provided in Slack. So before starting to integrate hokulea, bumped kona first.

Also `kona-client/v1.0.1` does not affect to us much, so was easy to bump. I scanned all of the changed files in kona and applied the related changes, and also scanned the bumped dependencies in kona which we have our own version such as `celo-alloy-consensus`, etc.