### PR TITLE
constants: Use `once_cell` instead of `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
  "auto_impl",
  "bincode 2.0.1",
  "celo-alloy-consensus",
- "lazy_static",
+ "once_cell",
  "op-alloy-consensus",
  "op-revm",
  "rand 0.9.1",
@@ -2130,6 +2130,12 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-epoch"
@@ -4228,6 +4234,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "op-alloy-consensus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ http-body-util = "0.1.3"
 unsigned-varint = "0.8.0"
 tracing-appender = "0.2.3"
 
+once_cell = { version = "1.19", default-features = false, features = ["alloc", "critical-section"] }
 rand = { version = "0.9.1", default-features = false }
 tabled = { version = "0.19", default-features = false }
 anyhow = { version = "1.0.98", default-features = false }

--- a/crates/celo-revm/Cargo.toml
+++ b/crates/celo-revm/Cargo.toml
@@ -43,11 +43,10 @@ op-alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 
 ## static precompile sets.
-#once_cell = { workspace = true, features = ["alloc"] }
+once_cell = { workspace = true, features = ["alloc"] }
 
 # misc
 auto_impl.workspace = true
-lazy_static = { workspace = true, features = ["spin_no_std"] }
 thiserror.workspace = true
 
 # Optional

--- a/crates/celo-revm/src/constants.rs
+++ b/crates/celo-revm/src/constants.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use revm::primitives::{Address, HashMap, address};
 
 pub const CELO_MAINNET_CHAIN_ID: u64 = 42220;
@@ -12,40 +12,38 @@ pub struct CeloAddresses {
 }
 
 // Static map of chain IDs to their addresses
-lazy_static! {
-    pub static ref CELO_ADDRESSES: HashMap<u64, CeloAddresses> = {
-        let mut m = HashMap::default();
+pub static CELO_ADDRESSES: Lazy<HashMap<u64, CeloAddresses>> = Lazy::new(|| {
+    let mut m = HashMap::default();
 
-        m.insert(
-            CELO_MAINNET_CHAIN_ID,
-            CeloAddresses {
-                celo_token: address!("0x471ece3750da237f93b8e339c536989b8978a438"),
-                fee_handler: address!("0xcd437749e43a154c07f3553504c68fbfd56b8778"),
-                fee_currency_directory: address!("0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276"),
-            },
-        );
+    m.insert(
+        CELO_MAINNET_CHAIN_ID,
+        CeloAddresses {
+            celo_token: address!("0x471ece3750da237f93b8e339c536989b8978a438"),
+            fee_handler: address!("0xcd437749e43a154c07f3553504c68fbfd56b8778"),
+            fee_currency_directory: address!("0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276"),
+        },
+    );
 
-        m.insert(
-            CELO_ALFAJORES_CHAIN_ID,
-            CeloAddresses {
-                celo_token: address!("0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"),
-                fee_handler: address!("0xEAaFf71AB67B5d0eF34ba62Ea06Ac3d3E2dAAA38"),
-                fee_currency_directory: address!("0x9212Fb72ae65367A7c887eC4Ad9bE310BAC611BF"),
-            },
-        );
+    m.insert(
+        CELO_ALFAJORES_CHAIN_ID,
+        CeloAddresses {
+            celo_token: address!("0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9"),
+            fee_handler: address!("0xEAaFf71AB67B5d0eF34ba62Ea06Ac3d3E2dAAA38"),
+            fee_currency_directory: address!("0x9212Fb72ae65367A7c887eC4Ad9bE310BAC611BF"),
+        },
+    );
 
-        m.insert(
-            CELO_BAKLAVA_CHAIN_ID,
-            CeloAddresses {
-                celo_token: address!("0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"),
-                fee_handler: address!("0xeed0A69c51079114C280f7b936C79e24bD94013e"),
-                fee_currency_directory: address!("0xD59E1599F45e42Eb356202B2C714D6C7b734C034"),
-            },
-        );
+    m.insert(
+        CELO_BAKLAVA_CHAIN_ID,
+        CeloAddresses {
+            celo_token: address!("0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8"),
+            fee_handler: address!("0xeed0A69c51079114C280f7b936C79e24bD94013e"),
+            fee_currency_directory: address!("0xD59E1599F45e42Eb356202B2C714D6C7b734C034"),
+        },
+    );
 
-        m
-    };
-}
+    m
+});
 
 /// Returns the addresses for the given chain ID, or Mainnet addresses if not found.
 pub fn get_addresses(chain_id: u64) -> &'static CeloAddresses {


### PR DESCRIPTION
While looking into `op-revm` and `reth`, `once_cell` is used everywhere and seems to be the more modern choice without macro usage.

This converts the constants to use `once_cell`.