### PR TITLE
Define EIP-1559 Base Fee Floor value

### DIFF
--- a/crates/kona/executor/src/builder/env.rs
+++ b/crates/kona/executor/src/builder/env.rs
@@ -1,7 +1,7 @@
 //! Environment utility functions for [CeloStatelessL2Builder].
 
 use super::CeloStatelessL2Builder;
-use crate::{constants::CELO_BASE_FEE_FLOOR, util::decode_holocene_eip_1559_params};
+use crate::{constants::CELO_EIP_1559_BASE_FEE_FLOOR, util::decode_holocene_eip_1559_params};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::{EvmEnv, EvmFactory};
@@ -67,7 +67,7 @@ where
         let mut next_block_base_fee = parent_header
             .next_block_base_fee(*base_fee_params)
             .unwrap_or_default();
-        next_block_base_fee = core::cmp::max(next_block_base_fee, CELO_BASE_FEE_FLOOR);
+        next_block_base_fee = core::cmp::max(next_block_base_fee, CELO_EIP_1559_BASE_FEE_FLOOR);
 
         let op_payload_attrs = &payload_attrs.op_payload_attributes.clone();
         Ok(BlockEnv {

--- a/crates/kona/executor/src/builder/env.rs
+++ b/crates/kona/executor/src/builder/env.rs
@@ -1,7 +1,7 @@
 //! Environment utility functions for [CeloStatelessL2Builder].
 
 use super::CeloStatelessL2Builder;
-use crate::util::decode_holocene_eip_1559_params;
+use crate::{constants::CELO_BASE_FEE_FLOOR, util::decode_holocene_eip_1559_params};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::{EvmEnv, EvmFactory};
@@ -67,8 +67,7 @@ where
         let mut next_block_base_fee = parent_header
             .next_block_base_fee(*base_fee_params)
             .unwrap_or_default();
-        // TODO: add CeloRollupConfig which includes eip1559_base_fee_floor and using it instead of hardcoding
-        next_block_base_fee = core::cmp::max(next_block_base_fee, 25_000_000_000);
+        next_block_base_fee = core::cmp::max(next_block_base_fee, CELO_BASE_FEE_FLOOR);
 
         let op_payload_attrs = &payload_attrs.op_payload_attributes.clone();
         Ok(BlockEnv {

--- a/crates/kona/executor/src/constants.rs
+++ b/crates/kona/executor/src/constants.rs
@@ -8,3 +8,6 @@ pub(crate) const HOLOCENE_EXTRA_DATA_VERSION: u8 = 0x00;
 /// Empty SHA-256 hash.
 pub(crate) const SHA256_EMPTY: B256 =
     b256!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+/// The Celo EIP-1559 base fee floor (in wei).
+pub(crate) const CELO_BASE_FEE_FLOOR: u64 = 25_000_000_000;

--- a/crates/kona/executor/src/constants.rs
+++ b/crates/kona/executor/src/constants.rs
@@ -10,4 +10,4 @@ pub(crate) const SHA256_EMPTY: B256 =
     b256!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
 /// The Celo EIP-1559 base fee floor (in wei).
-pub(crate) const CELO_BASE_FEE_FLOOR: u64 = 25_000_000_000;
+pub(crate) const CELO_EIP_1559_BASE_FEE_FLOOR: u64 = 25_000_000_000;


### PR DESCRIPTION
Closes https://github.com/celo-org/celo-blockchain-planning/issues/1093

This PR introduces the constant `CELO_BASE_FEE_FLOOR`, which represents the EIP-1559 base-fee floor in Celo chains. Because Mainnet, Alfajores, and Baklava currently share the same value and we don’t expect that to change soon, it just replaces the magic number with this named constant.