### PR TITLE
Additional network config in registry

### DIFF
--- a/crates/kona/registry/etc/configs.json
+++ b/crates/kona/registry/etc/configs.json
@@ -101,6 +101,81 @@
             "PreimageOracle": "0x3052f7e497870bE9aD7cd2C1fFC415c5Fb8ecFC3",
             "DataAvailabilityChallenge": null
           }
+        },
+        {
+          "Name": "Celo",
+          "PublicRPC": "https://forno.celo.org",
+          "SequencerRPC": "https://cel2-sequencer.celo.org/",
+          "Explorer": "https://celoscan.io/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "DataAvailabilityType": "alt-da",
+          "l2_chain_id": 42220,
+          "batch_inbox_address": "0xff00000000000000000000000000000000042220",
+          "block_time": 1,
+          "seq_window_size": 7200,
+          "max_sequencer_drift": 2892,
+          "GasPayingToken": "0x057898f3C43F129a17517B9056D23851F124b19f",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0
+          },
+          "optimism": {
+            "eip1559Elasticity": 5,
+            "eip1559Denominator": 400,
+            "eip1559DenominatorCanyon": 400
+          },
+          "alt_da": {
+            "da_challenge_window": 1,
+            "da_resolve_window": 1,
+            "da_commitment_type": "GenericCommitment"
+          },
+          "genesis": {
+            "l2_time": 1742957258,
+            "l1": {
+              "hash": "0xe499ec12e12fc2c94e6714a94f2640dbc748ff6c26fd3f420b25264a3d90066f",
+              "number": 22128103
+            },
+            "l2": {
+              "hash": "0x7586014e20c69b3fa7c9070baf1a7edd95833db57853126f32593b455da2e5c5",
+              "number": 31056500
+            },
+            "system_config": {
+              "batcherAddress": "0x0cd08c7f7A96AA9635f761b49216B9eA74C5cA60",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x0100000000000000000000000000000000000000000000000000000000000000",
+              "gasLimit": 30000000
+            }
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4092A77bAF58fef0309452cEaCb09221e556E112",
+            "ProxyAdminOwner": "0x4092A77bAF58fef0309452cEaCb09221e556E112",
+            "Guardian": "0x6E226fa22e5F19363d231D3FA048aaBa73CC1f47",
+            "Challenger": "0x6b145Ebf66602Ec524b196426B46631259689583",
+            "Proposer": "0x1204884E697efD929729B9A717Ea14496298A689",
+            "UnsafeBlockSigner": "0xA6F1c6c24De8b112dd3867dB907d187d490e6ddF",
+            "BatchSubmitter": "0x0cd08c7f7A96AA9635f761b49216B9eA74C5cA60"
+          },
+          "Addresses": {
+            "AddressManager": "0x55093104b76FAA602F9d6c35A5FFF576bE78d753",
+            "L1CrossDomainMessengerProxy": "0x1AC1181fc4e4F877963680587AEAa2C90D7EbB95",
+            "L1ERC721BridgeProxy": "0x3C519816C5BdC0a0199147594F83feD4F5847f13",
+            "L1StandardBridgeProxy": "0x9C4955b92F34148dbcfDCD82e9c9eCe5CF2badfe",
+            "L2OutputOracleProxy": "0x7617b249AEb1F06c90BDF9C4F6C903C09a6a4220",
+            "OptimismMintableERC20FactoryProxy": "0x6f0E4f1EB98A52EfaCF7BE11d48B9d9d6510A906",
+            "OptimismPortalProxy": "0xc5c5D157928BDBD2ACf6d0777626b6C75a9EAEDC",
+            "SystemConfigProxy": "0x89E31965D844a309231B1f17759Ccaf1b7c09861",
+            "ProxyAdmin": "0x783A434532Ee94667979213af1711505E8bFE374",
+            "SuperchainConfig": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
+            "AnchorStateRegistryProxy": "0xa24Bf5Bc02997f63da4e2C7F802067e05a102504",
+            "DelayedWETHProxy": "0xa316D42E8Fd98D2Ec364b8bF853d2623E768f95a",
+            "DisputeGameFactoryProxy": "0xFbAC162162f4009Bb007C6DeBC36B1dAC10aF683",
+            "MIPS": "0x8A12E1754f729C0856E2E32D4821577f0B245bfA",
+            "PreimageOracle": "0xfaB0F466955D87e596Ca87E20c505bB6470D0DC4"
+          }
         }
       ]
     }

--- a/crates/kona/registry/etc/configs.json
+++ b/crates/kona/registry/etc/configs.json
@@ -42,7 +42,9 @@
             "delta_time": 0,
             "ecotone_time": 0,
             "fjord_time": 0,
-            "granite_time": 0
+            "granite_time": 0,
+            "holocene_time": 1752073200,
+            "isthmus_time": 1752073200
           },
           "optimism": {
             "eip1559Elasticity": 5,

--- a/crates/kona/registry/etc/configs.json
+++ b/crates/kona/registry/etc/configs.json
@@ -1,6 +1,106 @@
 {
   "superchains": [
     {
+      "name": "mainnet",
+      "config": {
+        "name": "Mainnet",
+        "l1": {
+          "chain_id": 1,
+          "public_rpc": "https://ethereum-rpc.publicnode.com",
+          "explorer": "https://etherscan.io"
+        },
+        "hardforks": {
+          "canyon_time": 1704992401,
+          "delta_time": 1708560000,
+          "ecotone_time": 1710374401,
+          "fjord_time": 1720627201,
+          "granite_time": 1726070401,
+          "holocene_time": 1736445601,
+          "isthmus_time": 1746806401
+        },
+        "protocol_versions_addr": "0x8062abc286f5e7d9428a0ccb9abd71e50d93b935",
+        "superchain_config_addr": "0x95703e0982140d16f8eba6d158fccede42f04a4c",
+        "op_contracts_manager_proxy_addr": null
+      },
+      "chains": [
+        {
+          "Name": "Celo",
+          "PublicRPC": "https://forno.celo.org",
+          "SequencerRPC": "https://cel2-sequencer.celo.org/",
+          "Explorer": "https://celoscan.io/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "DataAvailabilityType": "alt-da",
+          "l2_chain_id": 42220,
+          "batch_inbox_address": "0xff00000000000000000000000000000000042220",
+          "block_time": 1,
+          "seq_window_size": 7200,
+          "max_sequencer_drift": 2892,
+          "GasPayingToken": "0x057898f3C43F129a17517B9056D23851F124b19f",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0
+          },
+          "optimism": {
+            "eip1559Elasticity": 5,
+            "eip1559Denominator": 400,
+            "eip1559DenominatorCanyon": 400
+          },
+          "alt_da": {
+            "da_challenge_window": 1,
+            "da_resolve_window": 1,
+            "da_commitment_type": "GenericCommitment"
+          },
+          "genesis": {
+            "l2_time": 1742957258,
+            "l1": {
+              "hash": "0xe499ec12e12fc2c94e6714a94f2640dbc748ff6c26fd3f420b25264a3d90066f",
+              "number": 22128103
+            },
+            "l2": {
+              "hash": "0x7586014e20c69b3fa7c9070baf1a7edd95833db57853126f32593b455da2e5c5",
+              "number": 31056500
+            },
+            "system_config": {
+              "batcherAddress": "0x0cd08c7f7A96AA9635f761b49216B9eA74C5cA60",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x0100000000000000000000000000000000000000000000000000000000000000",
+              "gasLimit": 30000000
+            }
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4092A77bAF58fef0309452cEaCb09221e556E112",
+            "ProxyAdminOwner": "0x4092A77bAF58fef0309452cEaCb09221e556E112",
+            "Guardian": "0x6E226fa22e5F19363d231D3FA048aaBa73CC1f47",
+            "Challenger": "0x6b145Ebf66602Ec524b196426B46631259689583",
+            "Proposer": "0x1204884E697efD929729B9A717Ea14496298A689",
+            "UnsafeBlockSigner": "0xA6F1c6c24De8b112dd3867dB907d187d490e6ddF",
+            "BatchSubmitter": "0x0cd08c7f7A96AA9635f761b49216B9eA74C5cA60"
+          },
+          "Addresses": {
+            "AddressManager": "0x55093104b76FAA602F9d6c35A5FFF576bE78d753",
+            "L1CrossDomainMessengerProxy": "0x1AC1181fc4e4F877963680587AEAa2C90D7EbB95",
+            "L1ERC721BridgeProxy": "0x3C519816C5BdC0a0199147594F83feD4F5847f13",
+            "L1StandardBridgeProxy": "0x9C4955b92F34148dbcfDCD82e9c9eCe5CF2badfe",
+            "L2OutputOracleProxy": "0x7617b249AEb1F06c90BDF9C4F6C903C09a6a4220",
+            "OptimismMintableERC20FactoryProxy": "0x6f0E4f1EB98A52EfaCF7BE11d48B9d9d6510A906",
+            "OptimismPortalProxy": "0xc5c5D157928BDBD2ACf6d0777626b6C75a9EAEDC",
+            "SystemConfigProxy": "0x89E31965D844a309231B1f17759Ccaf1b7c09861",
+            "ProxyAdmin": "0x783A434532Ee94667979213af1711505E8bFE374",
+            "SuperchainConfig": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
+            "AnchorStateRegistryProxy": "0xa24Bf5Bc02997f63da4e2C7F802067e05a102504",
+            "DelayedWETHProxy": "0xa316D42E8Fd98D2Ec364b8bF853d2623E768f95a",
+            "DisputeGameFactoryProxy": "0xFbAC162162f4009Bb007C6DeBC36B1dAC10aF683",
+            "MIPS": "0x8A12E1754f729C0856E2E32D4821577f0B245bfA",
+            "PreimageOracle": "0xfaB0F466955D87e596Ca87E20c505bB6470D0DC4"
+          }
+        }
+      ]
+    },
+    {
       "name": "holesky",
       "config": {
         "name": "Holesky",
@@ -100,81 +200,6 @@
             "PermissionedDisputeGame": "0x514088c8bD8dB7436858f21caCB628dbeF20a8F4",
             "PreimageOracle": "0x3052f7e497870bE9aD7cd2C1fFC415c5Fb8ecFC3",
             "DataAvailabilityChallenge": null
-          }
-        },
-        {
-          "Name": "Celo",
-          "PublicRPC": "https://forno.celo.org",
-          "SequencerRPC": "https://cel2-sequencer.celo.org/",
-          "Explorer": "https://celoscan.io/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "DataAvailabilityType": "alt-da",
-          "l2_chain_id": 42220,
-          "batch_inbox_address": "0xff00000000000000000000000000000000042220",
-          "block_time": 1,
-          "seq_window_size": 7200,
-          "max_sequencer_drift": 2892,
-          "GasPayingToken": "0x057898f3C43F129a17517B9056D23851F124b19f",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0
-          },
-          "optimism": {
-            "eip1559Elasticity": 5,
-            "eip1559Denominator": 400,
-            "eip1559DenominatorCanyon": 400
-          },
-          "alt_da": {
-            "da_challenge_window": 1,
-            "da_resolve_window": 1,
-            "da_commitment_type": "GenericCommitment"
-          },
-          "genesis": {
-            "l2_time": 1742957258,
-            "l1": {
-              "hash": "0xe499ec12e12fc2c94e6714a94f2640dbc748ff6c26fd3f420b25264a3d90066f",
-              "number": 22128103
-            },
-            "l2": {
-              "hash": "0x7586014e20c69b3fa7c9070baf1a7edd95833db57853126f32593b455da2e5c5",
-              "number": 31056500
-            },
-            "system_config": {
-              "batcherAddress": "0x0cd08c7f7A96AA9635f761b49216B9eA74C5cA60",
-              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
-              "scalar": "0x0100000000000000000000000000000000000000000000000000000000000000",
-              "gasLimit": 30000000
-            }
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4092A77bAF58fef0309452cEaCb09221e556E112",
-            "ProxyAdminOwner": "0x4092A77bAF58fef0309452cEaCb09221e556E112",
-            "Guardian": "0x6E226fa22e5F19363d231D3FA048aaBa73CC1f47",
-            "Challenger": "0x6b145Ebf66602Ec524b196426B46631259689583",
-            "Proposer": "0x1204884E697efD929729B9A717Ea14496298A689",
-            "UnsafeBlockSigner": "0xA6F1c6c24De8b112dd3867dB907d187d490e6ddF",
-            "BatchSubmitter": "0x0cd08c7f7A96AA9635f761b49216B9eA74C5cA60"
-          },
-          "Addresses": {
-            "AddressManager": "0x55093104b76FAA602F9d6c35A5FFF576bE78d753",
-            "L1CrossDomainMessengerProxy": "0x1AC1181fc4e4F877963680587AEAa2C90D7EbB95",
-            "L1ERC721BridgeProxy": "0x3C519816C5BdC0a0199147594F83feD4F5847f13",
-            "L1StandardBridgeProxy": "0x9C4955b92F34148dbcfDCD82e9c9eCe5CF2badfe",
-            "L2OutputOracleProxy": "0x7617b249AEb1F06c90BDF9C4F6C903C09a6a4220",
-            "OptimismMintableERC20FactoryProxy": "0x6f0E4f1EB98A52EfaCF7BE11d48B9d9d6510A906",
-            "OptimismPortalProxy": "0xc5c5D157928BDBD2ACf6d0777626b6C75a9EAEDC",
-            "SystemConfigProxy": "0x89E31965D844a309231B1f17759Ccaf1b7c09861",
-            "ProxyAdmin": "0x783A434532Ee94667979213af1711505E8bFE374",
-            "SuperchainConfig": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
-            "AnchorStateRegistryProxy": "0xa24Bf5Bc02997f63da4e2C7F802067e05a102504",
-            "DelayedWETHProxy": "0xa316D42E8Fd98D2Ec364b8bF853d2623E768f95a",
-            "DisputeGameFactoryProxy": "0xFbAC162162f4009Bb007C6DeBC36B1dAC10aF683",
-            "MIPS": "0x8A12E1754f729C0856E2E32D4821577f0B245bfA",
-            "PreimageOracle": "0xfaB0F466955D87e596Ca87E20c505bB6470D0DC4"
           }
         },
         {

--- a/crates/kona/registry/etc/configs.json
+++ b/crates/kona/registry/etc/configs.json
@@ -217,7 +217,7 @@
           "block_time": 1,
           "seq_window_size": 3600,
           "max_sequencer_drift": 1800,
-          "GasPayingToken": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "GasPayingToken": "0x3E3FEA3F31ff162a460f11Af4c53f39E743fd88c",
           "hardfork_configuration": {
             "canyon_time": 0,
             "delta_time": 0,

--- a/crates/kona/registry/etc/configs.json
+++ b/crates/kona/registry/etc/configs.json
@@ -176,6 +176,83 @@
             "MIPS": "0x8A12E1754f729C0856E2E32D4821577f0B245bfA",
             "PreimageOracle": "0xfaB0F466955D87e596Ca87E20c505bB6470D0DC4"
           }
+        },
+        {
+          "Name": "Celo Alfajores",
+          "PublicRPC": "https://alfajores-forno.celo-testnet.org",
+          "SequencerRPC": "https://sequencer.alfajores.celo-testnet.org",
+          "Explorer": "https://celo-alfajores.blockscout.com",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "DataAvailabilityType": "alt-da",
+          "l2_chain_id": 44787,
+          "batch_inbox_address": "0xff00000000000000000000000000000000044787",
+          "block_time": 1,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "GasPayingToken": "0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": 1750863600,
+            "isthmus_time": 1750863600
+          },
+          "optimism": {
+            "eip1559Elasticity": 5,
+            "eip1559Denominator": 400,
+            "eip1559DenominatorCanyon": 400
+          },
+          "alt_da": {
+            "da_challenge_window": 1,
+            "da_resolve_window": 1,
+            "da_commitment_type": "GenericCommitment"
+          },
+          "genesis": {
+            "l2_time": 1727337408,
+            "l1": {
+              "hash": "0x64728368a04f067bc2abe78c1de17f3711b054c4f3e979955fd8482af85e86db",
+              "number": 2411247
+            },
+            "l2": {
+              "hash": "0xe96cb39b59ebe02553e47424e7f57dbfbffca905c3ff350765985289754a00a3",
+              "number": 26384000
+            },
+            "system_config": {
+              "batcherAddr": "0x6f9cc6bfe1a0b446a36453d150905bbd6a4784e0",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xe571b94CF7e95C46DFe6bEa529335f4A11d15D92",
+            "ProxyAdminOwner": "0xe571b94CF7e95C46DFe6bEa529335f4A11d15D92",
+            "Guardian": "0xe571b94CF7e95C46DFe6bEa529335f4A11d15D92",
+            "Challenger": "0xe571b94CF7e95C46DFe6bEa529335f4A11d15D92",
+            "Proposer": "0x06d010A07D9076d6E7af80E54E26036941221bFA",
+            "UnsafeBlockSigner": "0x280F2AB4a7bC6c78bcFFBE91E9E369C5FB4e5a29",
+            "BatchSubmitter": "0x6f9cc6BfE1A0b446A36453d150905BBD6A4784e0"
+          },
+          "Addresses": {
+            "AddressManager": "0xF9f47a32F0BB1F92cF200b1CC9a1713F96b65284",
+            "L1CrossDomainMessengerProxy": "0xF1eE12842631A56a860A38C20B588F4Bb872a4F8",
+            "L1ERC721BridgeProxy": "0x514912297580a20B7a0C2930BC8503d2C13Da642",
+            "L1StandardBridgeProxy": "0xD1B0E0581973c9eB7f886967A606b9441A897037",
+            "L2OutputOracleProxy": "0x4a2635e9e4f6e45817b1D402ac4904c1d1752438",
+            "OptimismMintableERC20FactoryProxy": "0xa950F004F069B0bF9201b17e71549c7711d4a9d5",
+            "OptimismPortalProxy": "0x82527353927d8D069b3B452904c942dA149BA381",
+            "SystemConfigProxy": "0x499b0C1F4BDC76d61b1D13b03384eac65FAF50c7",
+            "ProxyAdmin": "0x4630583d066520aF0E3fda0de2C628EEd2888683",
+            "SuperchainConfig": "0x4da82a327773965b8d4d85fa3db8249b387458e7",
+            "AnchorStateRegistryProxy": "0x65c969f8ed6fb525cf4de41679c457ed92491a0e",
+            "DelayedWETHProxy": "0x8e2a6D372557c9661045f26B140E7A189C38D80C",
+            "DisputeGameFactoryProxy": "0xE28AAdcd9883746c0e5068F58f9ea06027b214cb",
+            "MIPS": "0xaa59a0777648bc75cd10364083e878c1ccd6112a",
+            "PreimageOracle": "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3"
+          }
         }
       ]
     }


### PR DESCRIPTION
Adds Celo mainnet and Alfajores config to the registry crate.

I copied the config for mainnet from the superchain-registry but ended up piecing together the config for Alfajores by hand from the config files linked below. It was quite laborious and feels like there must be a better way, so please let me know if I'm missing something.

https://storage.googleapis.com/cel2-rollup-files/alfajores/deployment-l1.json
https://storage.googleapis.com/cel2-rollup-files/alfajores/config.json
https://storage.googleapis.com/cel2-rollup-files/alfajores/rollup.json
https://storage.googleapis.com/cel2-rollup-files/alfajores/genesis.json