### PR TITLE
Bump hokulea to version that supports Holesky

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "canoe-bindings"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-sol-types",
 ]
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "eigenda-cert"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -2912,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-evm",
  "cfg-if",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "hokulea-eigenda"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -2938,6 +2938,7 @@ dependencies = [
  "kona-derive",
  "kona-protocol",
  "rust-kzg-bn254-primitives",
+ "serde",
  "thiserror",
  "tracing",
 ]
@@ -2945,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "hokulea-host-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -2972,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "hokulea-proof"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=0c8f62c#0c8f62c1ca4872ba9afcd37c421b350e75679809"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ revm-context = { version = "5.0.1", default-features = false }
 alloy-signer = { version = "1.0.9", default-features = false }
 
 # Hokulea
-hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "0c8f62c", default-features = false}
-hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "0c8f62c", default-features = false}
-hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "0c8f62c", default-features = false}
+hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748", default-features = false}
+hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748", default-features = false}
+hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748", default-features = false}
 
 # General
 url = "2.5.4"

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -9,8 +9,8 @@ use celo_genesis::CeloRollupConfig;
 use celo_proof::{CeloBootInfo, CeloOracleL2ChainProvider, executor::CeloExecutor};
 use celo_protocol::CeloToOpProviderAdapter;
 use core::fmt::Debug;
-use hokulea_eigenda::{EigenDABlobSource, EigenDADataSource};
-use hokulea_proof::eigenda_provider::OracleEigenDAProvider;
+use hokulea_eigenda::{EigenDADataSource, EigenDAPreimageSource};
+use hokulea_proof::eigenda_provider::OracleEigenDAPreimageProvider;
 use kona_client::single::FaultProofProgramError;
 use kona_derive::prelude::EthereumDataSource;
 use kona_executor::TrieDBProvider;
@@ -103,9 +103,9 @@ where
     let eth_data_source =
         EthereumDataSource::new_from_parts(l1_provider.clone(), beacon, &rollup_config);
 
-    let eigenda_blob_provider = OracleEigenDAProvider::new(oracle.clone());
-    let eigenda_blob_source = EigenDABlobSource::new(eigenda_blob_provider);
-    let da_provider = EigenDADataSource::new(eth_data_source, eigenda_blob_source);
+    let eigenda_preimage_provider = OracleEigenDAPreimageProvider::new(oracle.clone());
+    let eigenda_preimage_source = EigenDAPreimageSource::new(eigenda_preimage_provider);
+    let da_provider = EigenDADataSource::new(eth_data_source, eigenda_preimage_source);
 
     let pipeline = OraclePipeline::new(
         rollup_config.clone(),

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -5,7 +5,7 @@ use alloy_provider::RootProvider;
 use celo_alloy_network::Celo;
 use celo_genesis::CeloRollupConfig;
 use clap::Parser;
-use hokulea_host_bin::eigenda_blobs::OnlineEigenDABlobProvider;
+use hokulea_host_bin::eigenda_preimage::OnlineEigenDAPreimageProvider;
 use hokulea_proof::hint::ExtendedHintType;
 use kona_cli::cli_styles;
 use kona_host::{
@@ -170,14 +170,14 @@ impl CeloSingleChainHost {
                 .as_ref()
                 .ok_or(SingleChainHostError::Other("L2 node address must be set"))?,
         );
-        let eigen_da_blob_provider =
-            self.eigenda_proxy_address.clone().map(OnlineEigenDABlobProvider::new_http);
+        let eigen_da_preimage_provider =
+            self.eigenda_proxy_address.clone().map(OnlineEigenDAPreimageProvider::new_http);
 
         Ok(CeloSingleChainProviders {
             l1: l1_provider,
             blobs: blob_provider,
             l2: l2_provider,
-            eigenda_blob_provider: eigen_da_blob_provider,
+            eigenda_preimage_provider: eigen_da_preimage_provider,
         })
     }
 }
@@ -197,7 +197,7 @@ pub struct CeloSingleChainProviders {
     /// The L2 EL provider.
     pub l2: RootProvider<Celo>,
     /// The EigenDA blob provider
-    pub eigenda_blob_provider: Option<OnlineEigenDABlobProvider>,
+    pub eigenda_preimage_provider: Option<OnlineEigenDAPreimageProvider>,
 }
 
 #[cfg(test)]

--- a/bin/host/src/single/handler.rs
+++ b/bin/host/src/single/handler.rs
@@ -66,8 +66,8 @@ impl HintHandler for CeloSingleChainHintHandler {
                             ),
                             blobs: providers.blobs.clone(),
                         },
-                        eigenda_blob_provider: providers
-                            .eigenda_blob_provider
+                        eigenda_preimage_provider: providers
+                            .eigenda_preimage_provider
                             .as_ref()
                             .ok_or(anyhow!("Eigen DA blob provider must be set"))?
                             .clone(),


### PR DESCRIPTION
Some objects were renamed in the hokulea update, so
some changes were required here in order to account for that.