### PR TITLE
Bump hokulea to support EthDA proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "canoe-bindings"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-sol-types",
 ]
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "eigenda-cert"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -2913,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-evm",
  "cfg-if",
@@ -2931,7 +2931,7 @@ dependencies = [
 [[package]]
 name = "hokulea-eigenda"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "hokulea-host-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "hokulea-proof"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=2dae748#2dae748c69d7ace01ab1c1ff471e87449371893d"
+source = "git+https://github.com/Layr-Labs/hokulea?rev=ceffe35#ceffe35bc996dafa49f9cb6892d722dfbfa33abf"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ revm-context = { version = "5.0.1", default-features = false }
 alloy-signer = { version = "1.0.9", default-features = false }
 
 # Hokulea
-hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748", default-features = false}
-hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748", default-features = false}
-hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "2dae748", default-features = false}
+hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35", default-features = false}
+hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35", default-features = false}
+hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "ceffe35", default-features = false}
 
 # General
 url = "2.5.4"


### PR DESCRIPTION
The bumped hokulea version only includes the [single commit](https://github.com/Layr-Labs/hokulea/commit/ceffe35bc996dafa49f9cb6892d722dfbfa33abf) related to EthDA proving.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps all `hokulea` git dependencies to rev `ceffe35`, updating related crates in `Cargo.lock` to enable EthDA proving.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b069fb517875c840f69eab4d24d0aba8018e45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->