### PR TITLE
DONTMERGE: Fix alfajores base-fee-scalar

### DIFF
--- a/crates/celo-revm/src/handler.rs
+++ b/crates/celo-revm/src/handler.rs
@@ -489,6 +489,8 @@ where
             // and it will be reloaded from the database if it is not for the current block.
             if ctx.chain().l1_block_info.l2_block != block_number {
                 ctx.chain().l1_block_info = L1BlockInfo::try_fetch(ctx.db(), block_number, spec)?;
+                ctx.chain().l1_block_info.l1_base_fee_scalar = U256::ZERO;
+                ctx.chain().l1_block_info.l1_blob_base_fee_scalar = Some(U256::ZERO);
             }
 
             // account for additional cost of l1 fee and operator fee


### PR DESCRIPTION
On Alfajores we initially didn't have these set to zero but our cost function always returned zero. Then we decided to set these to zero and not change the cost function. We eventually set the fee scalars to zero in this block 32786341.

This is a hacky fix but should suffice to test alfjores excution before we shut it down in 2 weeks.


**This PR is just opened to build the images**