### PR TITLE
Add backfilling process in verify_new_heads

### DIFF
--- a/bin/execution-verifier/src/main.rs
+++ b/bin/execution-verifier/src/main.rs
@@ -219,10 +219,9 @@ async fn run(cli: ExecutionVerifierCommand, cancel_token: CancellationToken) -> 
         ));
     } else if let Some(start_block) = start_block {
         // Use dynamic concurrency for verify_new_heads
-        // verify_block_range is running => half capacity
+        // verify_block_range is running => 1
         // verify_block_range completes  => full capacity
-        let verify_new_heads_concurrency =
-            Arc::new(AtomicUsize::new(cli.concurrency / 2 + cli.concurrency % 2));
+        let verify_new_heads_concurrency = Arc::new(AtomicUsize::new(1));
 
         // Used to communicate the first head block so that we can set the end of the block range.
         let (first_head_tx, mut first_head_rx) = mpsc::channel(1);
@@ -248,7 +247,7 @@ async fn run(cli: ExecutionVerifierCommand, cancel_token: CancellationToken) -> 
                     end,
                     provider.clone(),
                     rollup_config.clone(),
-                    cli.concurrency / 2,
+                    std::cmp::max(1, cli.concurrency - 1),
                     cancel_token.clone(),
                     metrics.clone(),
                     tracker.clone(),


### PR DESCRIPTION
Addresses https://github.com/celo-org/celo-blockchain-planning/issues/1246

`verify_new_heads` of execution-verifier subscribes to new head events and verifies the block at each received height. However, gaps can occur between iterations (e.g. due to network disconnects or slow processing in the loop). 

This PR replaces `verify_block` with `verify_block_range` in `verify_new_heads`, passing an inclusive height range to backfill gaps and keep verification continuous.
