### PR TITLE
fix(security): patch kona vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "canoe-bindings"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "canoe-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "canoe-verifier-address-fetcher"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-primitives",
  "eigenda-cert",
@@ -2468,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "eigenda-cert"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3029,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.24.2",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-evm 0.24.2",
  "alloy-op-evm",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "hokulea-eigenda"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "hokulea-host-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -3113,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "hokulea-proof"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.5#bf561ccda57b8a043d6b403a225c579eacf82de3"
+source = "git+https://github.com/celo-org/hokulea?branch=kona-proof-fix#278ebc2c2f5cf11e9aa0d6549f7d7697ef4963b7"
 dependencies = [
  "alloy-primitives",
  "ark-bn254",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.3.2"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "1.0.2"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3648,7 +3648,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3669,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.24.2",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "1.0.2"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.4.5"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3829,12 +3829,12 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -3859,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.3.3"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "async-trait",
  "buddy_system_allocator",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/celo-org/kona?rev=ce6c778e#ce6c778ed1ff3bba3910bd116e0db2f4bfe51d3a"
+source = "git+https://github.com/celo-org/kona?rev=cf790b7#cf790b7405b16510f1fb023bd8e4f0eca9ac8eb7"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,18 +218,27 @@ alloy-eips = { git = "https://github.com/celo-org/alloy", branch = "fix-fake-exp
 alloy-serde = { git = "https://github.com/celo-org/alloy", branch = "fix-fake-exponential-v1.5.2" }
 
 [patch."https://github.com/op-rs/kona"]
-kona-host = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-client = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-driver   = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-derive   = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-genesis  = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-protocol = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-registry = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-providers-alloy = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-mpt        = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-proof      = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-executor   = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-std-fpvm   = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-preimage   = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-std-fpvm-proc = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
-kona-cli   = { git = "https://github.com/celo-org/kona", rev = "ce6c778e" }
+kona-host = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-client = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-driver   = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-derive   = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-genesis  = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-protocol = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-registry = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-providers-alloy = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-mpt        = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-proof      = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-executor   = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-std-fpvm   = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-preimage   = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-std-fpvm-proc = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+kona-cli   = { git = "https://github.com/celo-org/kona", rev = "cf790b7" }
+
+# TODO: Remove this patch once Hokulea is upgraded to a version that includes
+# the Kona update from:
+# https://github.com/ethereum-optimism/optimism/commit/b08e543ddfb2c49be51a351c10135bdedcb8152d
+# Also remove this entry from deny.toml.
+[patch."https://github.com/Layr-Labs/hokulea"]
+hokulea-eigenda = { git = "https://github.com/celo-org/hokulea", branch = "kona-proof-fix" }
+hokulea-proof = { git = "https://github.com/celo-org/hokulea", branch = "kona-proof-fix" }
+hokulea-host-bin = { git = "https://github.com/celo-org/hokulea", branch = "kona-proof-fix" }

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -73,16 +73,6 @@ where
         ));
     }
 
-    // In the case where the agreed upon L2 output root is the same as the claimed L2 output root,
-    // trace extension is detected and we can skip the derivation and execution steps.
-    if boot.op_boot_info.agreed_l2_output_root == boot.op_boot_info.claimed_l2_output_root {
-        info!(
-            target: "client",
-            "Trace extension detected. State transition is already agreed upon.",
-        );
-        return Ok(());
-    }
-
     ////////////////////////////////////////////////////////////////
     //                   DERIVATION & EXECUTION                   //
     ////////////////////////////////////////////////////////////////
@@ -91,6 +81,7 @@ where
     let cursor = new_oracle_pipeline_cursor(
         rollup_config.as_ref(),
         safe_head,
+        boot.op_boot_info.agreed_l2_output_root,
         &mut l1_provider,
         // new_oracle_pipeline_cursor requires l2_block_info_by_number
         &mut CeloToOpProviderAdapter(l2_provider.clone()),

--- a/deny.toml
+++ b/deny.toml
@@ -47,7 +47,7 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [licenses.private]
 ignore = true
-ignore-sources = ["https://github.com/Layr-Labs/hokulea"]
+ignore-sources = ["https://github.com/Layr-Labs/hokulea", "https://github.com/celo-org/hokulea"]
 
 [bans]
 multiple-versions = "warn"
@@ -71,7 +71,8 @@ allow-git = [
     "https://github.com/op-rs/kona",
     "https://github.com/celo-org/kona",
     "https://github.com/celo-org/revm",
-    "https://github.com/celo-org/alloy"
+    "https://github.com/celo-org/alloy",
+    "https://github.com/celo-org/hokulea"
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
## Summary

Patches upstream kona vulnerabilities (https://github.com/ethereum-optimism/optimism/commit/b08e543ddfb2c49be51a351c10135bdedcb8152d) by applying it to our own fork which [cherry-picked the official fixes](https://github.com/celo-org/kona/compare/palango/replace-max-sequencer-drift-v1.2.7...kona-proof-fix) on top of our current kona version. Also needed to patch [hokulea](https://github.com/Layr-Labs/hokulea/compare/hokulea-client/v1.1.5...celo-org:hokulea:kona-proof-fix) to resolve compile errors caused by the changing interface of `new_oracle_pipeline_cursor` function. This patch should be removed once Hokulea is upgraded to a version that uses the kona version with the fix.

There are total 3 vulnerability issues in kona.
1. Issues that do not require a malicious batcher
1-1) Channel decompression behavior can diverge from OP Stack semantics (and may cause DoS)
1-2) Faulty trace extension can allow an attacker to win dispute games (kona-client only)
1-3) Invalid output root validation via zero-initialized safe-head output root

Among those, fixed vulnerabilities are 1-1 and 1-3. For 1-2, this was independently discovered and fixed in op-succinct v3.0.0 via PR https://github.com/succinctlabs/op-succinct/pull/550 ([GHSA-8pwr-p276-45mf](https://github.com/succinctlabs/op-succinct/security/advisories/GHSA-8pwr-p276-45mf)), which removed the shortcut entirely. So removed the shortcut as well in celo-client.

Related to https://github.com/celo-org/celo-blockchain-planning/issues/1352