### PR TITLE
fix(security): add trace-extension short-circuit check

### DIFF
--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -73,6 +73,32 @@ where
         ));
     }
 
+    // If the claim targets the safe head block itself, then no derivation is required. This can
+    // happen at trace-extension leaves where the trace is capped at the root-claim block number.
+    //
+    // In this case, the only valid output root is the agreed output root (a zero-step transition).
+    if boot.op_boot_info.claimed_l2_block_number == safe_head.number {
+        if boot.op_boot_info.claimed_l2_output_root != boot.op_boot_info.agreed_l2_output_root {
+            error!(
+                target: "client",
+                claimed = boot.op_boot_info.claimed_l2_block_number,
+                safe = safe_head.number,
+                expected_output_root = ?boot.op_boot_info.agreed_l2_output_root,
+                claimed_output_root = ?boot.op_boot_info.claimed_l2_output_root,
+                "Claimed output root does not match agreed output root at safe head",
+            );
+            return Err(FaultProofProgramError::InvalidClaim(
+                boot.op_boot_info.agreed_l2_output_root,
+                boot.op_boot_info.claimed_l2_output_root,
+            ));
+        }
+        info!(
+            target: "client",
+            "Trace extension detected. State transition is already agreed upon.",
+        );
+        return Ok(());
+    }
+
     ////////////////////////////////////////////////////////////////
     //                   DERIVATION & EXECUTION                   //
     ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- Adds the missing trace-extension short-circuit check that was dropped in #147 
- The kona security patch branch (https://github.com/celo-org/kona/tree/kona-proof-fix) [replaced the old output-root-based trace extension check with a block-number-based one](https://github.com/celo-org/kona/commit/71493684129b2e9d1ce8e1844515a0468466fce7), but #147 removed the check entiresly from our celo customised `single.rs` implementation without porting the replacement.

In the context of op-succinct which removed the trace extension check entirely, this made sense (see [this comment](https://github.com/celo-org/celo-kona/pull/147#discussion_r3010601992) on #147)

But I believe that this caused  the celo-kona Proof workflow failure seen [here](https://github.com/celo-org/celo-kona/actions/runs/23798478182/job/69351980954)  which occurs when running the kona host outside of an op-succinct context.

When `claimed_l2_block_number == safe_head.number`, no derivation is needed — the only valid claim is the agreed output root (zero-step transition). Without this check, the `celo-host` e2e test aborts during cleanup (exit code 134) after otherwise completing successfully.

Since op-succinct handles this at a higher level in its proving pipeline (trace extension check removed in op-succinct v3.0.0 PR #550), I think it is safe and correct for the check to exist in celo-kona for situations when `celo-host` is run directly (e.g. in e2e native tests) without op-succinct.