### PR TITLE
Bump hokulea to v1.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "canoe-bindings"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "canoe-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "canoe-verifier-address-fetcher"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-primitives",
  "eigenda-cert",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "eigenda-cert"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.27.3",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-evm 0.27.3",
  "alloy-op-evm",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "hokulea-eigenda"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "hokulea-host-bin"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "hokulea-proof"
 version = "0.1.0"
-source = "git+https://github.com/Layr-Labs/hokulea?rev=e93c95c01014da064486205e727b74ce076471b5#e93c95c01014da064486205e727b74ce076471b5"
+source = "git+https://github.com/Layr-Labs/hokulea?tag=hokulea-client%2Fv1.1.7#22c48b995b05486fa300510316c78173e6ecc3f3"
 dependencies = [
  "alloy-primitives",
  "ark-bn254",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6423,9 +6423,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,9 +152,9 @@ revm-handler = { version = "15.0.0", default-features = false }
 revm-context = { version = "13.0.0", default-features = false }
 
 # Hokulea
-hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", rev = "e93c95c01014da064486205e727b74ce076471b5", default-features = false }
-hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", rev = "e93c95c01014da064486205e727b74ce076471b5", default-features = false }
-hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", rev = "e93c95c01014da064486205e727b74ce076471b5", default-features = false }
+hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", tag = "hokulea-client/v1.1.7", default-features = false }
+hokulea-proof = { git = "https://github.com/Layr-Labs/hokulea", tag = "hokulea-client/v1.1.7", default-features = false }
+hokulea-host-bin = { git = "https://github.com/Layr-Labs/hokulea", tag = "hokulea-client/v1.1.7", default-features = false }
 
 # General
 url = { version = "2.5.8", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -12,8 +12,6 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsoundness with custom logger using rand::rng(); not triggered by our usage
-    "RUSTSEC-2026-0097",
 ]
 
 [licenses]


### PR DESCRIPTION
Bump hokulea to [v1.1.7](https://github.com/Layr-Labs/hokulea/releases/tag/hokulea-client%2Fv1.1.7) to apply sp1 crates bump to v6.1.0. Also decided to first try out the combination of Hypercube (SP1 v6.1.0) & kona v1.2.13 to start testing early with the latest version of celo-kona and keep up-to-date with upstream.