### PR TITLE
chore: ignore RUSTSEC-2026-0118 (hickory-proto NSEC3 DoS)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,12 @@ ignore = [
     # dropped DnssecDnsHandle entirely; hickory-resolver 0.25.x (used by reth) has not been
     # updated to that, so we cannot force a patched version without upgrading reth.
     "RUSTSEC-2026-0118",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0119 hickory-proto O(n²) name compression
+    # during message encoding (CPU exhaustion). Patched in hickory-proto >= 0.26.1, which
+    # cannot be pulled in without bumping reth-dns-discovery's hickory-resolver 0.25.x pin.
+    # Exposure here is narrow: encoding amplification needs an attacker who can influence the
+    # records reth-dns-discovery puts into outgoing messages, not just respond to queries.
+    "RUSTSEC-2026-0119",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,14 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained, need to transition all deps to wincode first
     "RUSTSEC-2025-0141",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0118 hickory-proto NSEC3 closest-encloser
+    # proof DoS. Reachable only via `DnssecDnsHandle`, which requires the `dnssec-ring` or
+    # `dnssec-aws-lc-rs` feature on hickory-proto/hickory-resolver. We pull hickory-resolver
+    # in transitively through reth-dns-discovery, which enables only the `tokio` feature, so
+    # the vulnerable code path is not reachable. The fix lives in hickory-proto >= 0.26, which
+    # dropped DnssecDnsHandle entirely; hickory-resolver 0.25.x (used by reth) has not been
+    # updated to that, so we cannot force a patched version without upgrading reth.
+    "RUSTSEC-2026-0118",
 ]
 
 [licenses]


### PR DESCRIPTION
The vulnerable DnssecDnsHandle path requires the dnssec-ring or dnssec-aws-lc-rs feature, which reth-dns-discovery does not enable on its transitive hickory-resolver dependency. The fix lives in hickory-proto >= 0.26, which removed DnssecDnsHandle entirely; hickory-resolver 0.25.x has not been updated to track that.