### PR TITLE
Container tags job in ubuntu-slim

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   infer_image_metadata:
     name: Infer image tags from github ref type
-    runs-on: [self-hosted, org, 8-cpu]
+    runs-on: ubuntu-slim
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
For this "simple" job, using github's `ubuntu-slim` will be much faster