### PR TITLE
refactor: replace Cip64Storage VecDeque with single-slot Option

### DIFF
--- a/crates/alloy-celo-evm/src/cip64_storage.rs
+++ b/crates/alloy-celo-evm/src/cip64_storage.rs
@@ -3,7 +3,7 @@
 //! This module provides a thread-safe storage mechanism for sharing CIP-64 transaction
 //! execution results between the EVM handler and the receipt builder.
 
-use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::Address;
 use celo_revm::Cip64Info;
 use revm::primitives::Log;
@@ -20,39 +20,55 @@ pub struct Cip64ReceiptData {
 
 /// Shared storage for CIP-64 transaction execution results.
 ///
-/// The `receipt_queue` is a FIFO consumed by the receipt builder as each CIP-64
-/// transaction is processed. The optional `all_entries` Vec (gated behind the
-/// `test-utils` feature) accumulates every entry without consuming them, and
-/// exists purely so test harnesses can inspect post-execution CIP-64 gas
-/// accounting. It must stay off in production: `store_cip64_info` runs on every
-/// CIP-64 tx, and an unbounded Vec on a long-running node would leak memory
-/// linearly with CIP-64 tx volume.
+/// `pending` is a single slot consumed by the receipt builder after each CIP-64
+/// transaction. The block executor is strictly serial — every `transact_raw`
+/// for a CIP-64 tx is followed by `build_receipt` for that same tx before the
+/// next `transact_raw` — so one slot is sufficient. Storing more than one
+/// entry would mean `transact_raw` ran twice without an intervening
+/// `build_receipt` (e.g. an executor that skips commit on a per-tx condition,
+/// retries, or parallelises), which would silently swap receipt logs / base
+/// fee between txs and corrupt the receipts root. `store_cip64_info` panics
+/// when the slot is already occupied to turn that silent corruption into a
+/// loud, immediate failure.
+///
+/// The optional `all_entries` Vec (gated behind the `test-utils` feature)
+/// accumulates every entry without consuming them, and exists purely so test
+/// harnesses can inspect post-execution CIP-64 gas accounting. It must stay
+/// off in production: `store_cip64_info` runs on every CIP-64 tx, and an
+/// unbounded Vec on a long-running node would leak memory linearly with
+/// CIP-64 tx volume.
 #[derive(Debug, Clone, Default)]
 pub struct Cip64Storage {
-    /// Queue of receipt data in transaction execution order (consumed by receipt builder).
-    receipt_queue: Arc<Mutex<VecDeque<Cip64ReceiptData>>>,
+    /// Single-slot pending receipt data (consumed by receipt builder).
+    pending: Arc<Mutex<Option<Cip64ReceiptData>>>,
     /// Accumulated entries for post-execution inspection (test-only).
     #[cfg(any(test, feature = "test-utils"))]
     all_entries: Arc<Mutex<Vec<Cip64ReceiptData>>>,
 }
 
 impl Cip64Storage {
-    /// Stores CIP-64 execution info for a transaction, enqueueing it for receipt building.
+    /// Stores CIP-64 execution info for a transaction, to be consumed by the next
+    /// `build_receipt` call.
+    ///
+    /// Panics if the slot is already occupied: that means the executor invoked
+    /// `transact_raw` for two CIP-64 txs without `build_receipt` running between
+    /// them, which would corrupt the second tx's receipt. Failing loud here
+    /// catches the bug at its source instead of at receipts-root divergence.
     pub fn store_cip64_info(&self, fee_currency: Option<Address>, info: Cip64Info) {
         let data = Cip64ReceiptData { fee_currency, cip64_info: info };
         #[cfg(any(test, feature = "test-utils"))]
         self.all_entries.lock().push(data.clone());
-        self.receipt_queue.lock().push_back(data);
+        let prev = self.pending.lock().replace(data);
+        assert!(
+            prev.is_none(),
+            "Cip64Storage: store_cip64_info called with slot occupied — \
+             executor invariant violated (transact_raw without intervening build_receipt)"
+        );
     }
 
-    /// Pops the next CIP-64 receipt data from the queue for receipt building.
+    /// Takes the pending CIP-64 receipt data for receipt building.
     pub fn pop_cip64_receipt_data(&self) -> Option<Cip64ReceiptData> {
-        self.receipt_queue.lock().pop_front()
-    }
-
-    /// Number of receipt entries waiting to be drained. Should be zero between blocks.
-    pub fn pending_receipt_count(&self) -> usize {
-        self.receipt_queue.lock().len()
+        self.pending.lock().take()
     }
 
     /// Returns all stored CIP-64 receipt data entries (not consumed by this call).
@@ -80,17 +96,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn receipt_queue_drained_by_pop() {
-        // Fundamental invariant: the consuming queue keeps no history of its
-        // own — once the receipt builder pops an entry, the queue shrinks.
-        // If this ever regressed, celo-reth would leak memory identically to
-        // the pre-fix `all_entries` case.
+    fn slot_drained_by_pop() {
         let storage = Cip64Storage::default();
-        for _ in 0..100 {
-            storage.store_cip64_info(None, Cip64Info::default());
-        }
-        assert_eq!(storage.receipt_queue.lock().len(), 100);
-        while storage.pop_cip64_receipt_data().is_some() {}
-        assert_eq!(storage.receipt_queue.lock().len(), 0);
+        storage.store_cip64_info(None, Cip64Info::default());
+        assert!(storage.pop_cip64_receipt_data().is_some());
+        assert!(storage.pop_cip64_receipt_data().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "store_cip64_info called with slot occupied")]
+    fn double_store_without_pop_panics() {
+        let storage = Cip64Storage::default();
+        storage.store_cip64_info(None, Cip64Info::default());
+        storage.store_cip64_info(None, Cip64Info::default());
     }
 }

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -284,9 +284,10 @@ where
                 // CIP64 NOTE:
                 // Extract and store the cip64 info to a shared storage to be able to add the
                 // credit/debit logs when building the receipt in the receipts_builder.
-                // Only enqueue during block building: RPC simulation paths (eth_call,
-                // eth_estimateGas) never drain the FIFO, so a stale entry would be popped
-                // by the next real block's first CIP-64 tx and corrupt its receipt.
+                // Only store during block building: RPC simulation paths (eth_call,
+                // eth_estimateGas) never drain the slot, so a stale entry would be picked up
+                // by the next real block's first CIP-64 tx and corrupt its receipt (or trip
+                // the slot-occupied assertion in `store_cip64_info`).
                 let cip64_info = self.inner.inner.0.ctx.tx.cip64_tx_info.take();
                 if is_block_building && let Some(cip64_info) = cip64_info {
                     self.cip64_storage.store_cip64_info(fee_currency, cip64_info);
@@ -495,24 +496,6 @@ impl CeloEvmFactory {
     ) -> CeloEvm<DB, I, PrecompilesMap> {
         input.cfg_env.limit_contract_code_size = Some(constants::CELO_MAX_CODE_SIZE);
         let spec_id = input.cfg_env.spec;
-        // Defense in depth for the receipt FIFO: when constructing a block-building EVM,
-        // the shared queue should be empty — pending entries mean a previous block leaked
-        // (or a non-block-building path enqueued without draining). Debug-only; the real
-        // protection is the `is_block_building` gate in `transact_raw`.
-        //
-        // Without `optional_no_base_fee` the base-fee check cannot be skipped, so every
-        // EVM constructed here is a block-building EVM and the assertion always applies.
-        #[cfg(feature = "optional_no_base_fee")]
-        let is_block_building = !input.cfg_env.disable_base_fee;
-        #[cfg(not(feature = "optional_no_base_fee"))]
-        let is_block_building = true;
-        if is_block_building && let Some(storage) = &self.cip64_storage {
-            let pending = storage.pending_receipt_count();
-            debug_assert!(
-                pending == 0,
-                "Cip64Storage queue not empty at block start: {pending} entries leaked"
-            );
-        }
         CeloEvm {
             inner: Context::celo()
                 .with_db(db)
@@ -677,9 +660,10 @@ mod tests {
     }
 
     /// Verify that RPC simulation paths (eth_call / eth_estimateGas) never
-    /// enqueue CIP-64 receipt data. The receipt builder only runs during real
-    /// block execution, so any entry left here would be popped by the next
-    /// real block's first CIP-64 tx and corrupt its receipt logs / base fee.
+    /// store CIP-64 receipt data. The receipt builder only runs during real
+    /// block execution, so any entry left here would be picked up by the next
+    /// real block's first CIP-64 tx and corrupt its receipt (or trip the
+    /// slot-occupied assertion in `store_cip64_info`).
     ///
     /// The handler still populates `cip64_tx_info` during simulation for
     /// native-fee CIP-64 txs (`feeCurrency == 0x0`), so this guard lives in
@@ -703,7 +687,7 @@ mod tests {
 
         // Native-fee CIP-64 tx (`fee_currency = 0x0`): the handler sets
         // `cip64_tx_info = Some(..)` on this path even when base fee is
-        // disabled, so the only line of defense against polluting the FIFO is
+        // disabled, so the only line of defense against polluting the slot is
         // the `is_block_building` gate in `transact_raw`.
         let mut tx = make_cip64_tx(Address::ZERO);
         tx.fee_currency = Some(Address::ZERO);
@@ -712,24 +696,8 @@ mod tests {
 
         assert!(
             evm.cip64_storage.pop_cip64_receipt_data().is_none(),
-            "RPC simulation must not enqueue CIP-64 receipt data"
+            "RPC simulation must not store CIP-64 receipt data"
         );
-    }
-
-    /// Verify that the block-start `debug_assert!` fires when the receipt FIFO has
-    /// pending entries. This is a regression guard: any future leak (sim path
-    /// enqueuing without draining, executor failing to consume entries, etc.) will
-    /// trip this on the next block-building EVM creation rather than silently
-    /// corrupting that block's receipts.
-    #[test]
-    #[should_panic(expected = "queue not empty at block start")]
-    fn test_block_start_panics_on_leaked_cip64_entry() {
-        use celo_revm::Cip64Info;
-        let storage = Cip64Storage::default();
-        storage.store_cip64_info(None, Cip64Info::default());
-        let factory = CeloEvmFactory::with_cip64_storage(storage);
-        let _evm = factory
-            .create_evm(revm::database::InMemoryDB::default(), EvmEnv::<OpSpecId>::default());
     }
 
     /// Verify that the blocklist is NOT enforced during RPC simulation


### PR DESCRIPTION
The shared CIP-64 receipt buffer between the EVM handler and the receipt builder was a FIFO matched to receipts only by position. The strict serial transact_raw -> build_receipt pairing in the block executor made that work today, but a future executor change (commit-condition skip, retry, parallel simulation) would silently swap receipt logs / base fee between txs.

Single-slot semantics make the contract explicit: store_cip64_info panics when the slot is already occupied, turning silent receipts-root corruption into a loud, immediate failure at the offending push.

This also lets us drop the block-start debug_assert and pending_receipt_count helper, since the slot-occupied panic catches every leak path before it could be observed by the receipt builder.