### PR TITLE
Apply advisory fixes for kona-executor and range proof commitment to mismatched l2BlockNumber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.26.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -412,7 +412,7 @@ dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
- "op-alloy 0.23.1 (git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13)",
+ "op-alloy 0.23.1 (git+https://github.com/celo-org/optimism?rev=b4ba5c3)",
  "op-revm",
  "revm 34.0.0",
  "thiserror 2.0.18",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "ambassador"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8184c5d23ba3829fb1e93388d776c3469cd9f4162af65250490b4f22d3ecf614"
+checksum = "cd3d4da7fddbc6567cbd7b5c30364f91313701b1857ab5b925eb3acf06162eed"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -5084,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "kona-cli"
 version = "0.3.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "1.0.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5143,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "kona-driver"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm 0.27.3",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.4.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "kona-genesis"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5244,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "kona-hardforks"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5255,7 +5255,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "1.0.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "kona-interop"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5325,12 +5325,12 @@ dependencies = [
 [[package]]
 name = "kona-macros"
 version = "0.1.2"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 
 [[package]]
 name = "kona-mpt"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5342,7 +5342,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-primitives",
  "async-channel",
@@ -5355,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "kona-proof"
 version = "0.3.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5391,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "kona-proof-interop"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5423,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "kona-protocol"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -5455,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.3.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5486,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "kona-registry"
 version = "0.4.5"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "async-trait",
  "buddy_system_allocator",
@@ -5518,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "kona-std-fpvm-proc"
 version = "0.2.0"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "cfg-if",
  "kona-std-fpvm",
@@ -6313,11 +6313,11 @@ dependencies = [
 [[package]]
 name = "op-alloy"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
- "op-alloy-provider 0.23.1 (git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13)",
+ "op-alloy-provider 0.23.1 (git+https://github.com/celo-org/optimism?rev=b4ba5c3)",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
 ]
@@ -6325,7 +6325,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6350,7 +6350,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6380,7 +6380,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -6403,7 +6403,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6422,7 +6422,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9252,7 +9252,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9280,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-evm"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-exex"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9402,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-flashblocks"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9440,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9451,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-node"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9505,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-storage"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "reth-optimism-primitives",
@@ -9641,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-trie"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-txpool"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=kona-client%2Fv1.2.13#348e12919d270b600bc26863f8223c529aacc90c"
+source = "git+https://github.com/celo-org/optimism?rev=b4ba5c3#b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,33 +84,33 @@ celo-revm = { version = "1.0.0", path = "crates/celo-revm", default-features = f
 celo-registry = { version = "1.0.0", path = "crates/kona/registry", default-features = false }
 celo-otel = { version = "1.0.0", path = "crates/celo-otel", default-features = false }
 celo-reth = { version = "0.1.0", path = "crates/celo-reth", default-features = false }
+
 # TODO: When bumping kona past https://github.com/ethereum-optimism/optimism/commit/8fbd06ec,
 # configure the correct max_sequencer_drift via the new configurable parameter.
-
 # Binaries
-kona-host = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-client = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
+kona-host = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-client = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # Protocol
-kona-driver = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-derive = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-genesis = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-protocol = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-registry = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
+kona-driver = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-derive = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-genesis = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-protocol = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-registry = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # Providers
-kona-providers-alloy = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
+kona-providers-alloy = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # Proof
-kona-mpt = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-proof = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-executor = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-std-fpvm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-preimage = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-kona-std-fpvm-proc = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
+kona-mpt = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-proof = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-executor = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-std-fpvm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-preimage = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+kona-std-fpvm-proc = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # Utilities
-kona-cli = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
+kona-cli = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
 
 # Alloy
 alloy-rlp = { version = "0.3.13", default-features = false }
@@ -178,17 +178,17 @@ reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3" }
 
 # OP Reth
-reth-optimism-chainspec = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-reth-optimism-cli = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-reth-optimism-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-reth-optimism-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-reth-optimism-forks = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-reth-optimism-node = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-reth-optimism-payload-builder = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-reth-optimism-primitives = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13", default-features = false }
-reth-optimism-rpc = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-reth-optimism-storage = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-reth-optimism-txpool = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
+reth-optimism-chainspec = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+reth-optimism-cli = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+reth-optimism-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+reth-optimism-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+reth-optimism-forks = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+reth-optimism-node = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
+reth-optimism-payload-builder = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
+reth-optimism-primitives = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14", default-features = false }
+reth-optimism-rpc = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
+reth-optimism-storage = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
+reth-optimism-txpool = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.14" }
 
 # Hokulea
 hokulea-eigenda = { git = "https://github.com/Layr-Labs/hokulea", tag = "hokulea-client/v1.1.7", default-features = false }
@@ -266,12 +266,40 @@ alloy-eips = { git = "https://github.com/celo-org/alloy", branch = "fix-fake-exp
 # We also need to patch alloy-serde to this version since otherwise a different non patch version is also included in the project
 # which breaks trait bound satisfaction
 alloy-serde = { git = "https://github.com/celo-org/alloy", branch = "fix-fake-exponential-v1.6.3" }
-# Pin op-alloy and alloy-op-* crates to the upstream ethereum-optimism/optimism
-# monorepo at `kona-client/v1.2.13`, matching the kona patches below so all
-# kona/op-reth dependencies resolve to a single source.
-op-alloy-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-op-alloy-rpc-types-engine = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-op-alloy-rpc-types = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
-alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-client/v1.2.13" }
+# Pin op-alloy and alloy-op-* crates to the same version as the kona crates rely on, 
+# so kona/op-alloy dependencies resolve to a single source.
+op-alloy-consensus = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+op-alloy-rpc-types-engine = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+op-alloy-rpc-types = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+op-alloy-network = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+alloy-op-hardforks = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+alloy-op-evm = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+
+# TODO: remove these patches when bumping kona past https://github.com/ethereum-optimism/optimism/commit/f1930fa
+[patch."https://github.com/ethereum-optimism/optimism"]
+kona-host = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-client = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-driver = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-derive = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-genesis = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-protocol = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-registry = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-providers-alloy = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-mpt = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-proof = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-executor = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-std-fpvm = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-preimage = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-std-fpvm-proc = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+kona-cli = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-chainspec = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-cli = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-consensus = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-evm = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-forks = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-node = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-payload-builder = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-primitives = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-rpc = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-storage = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }
+reth-optimism-txpool = { git = "https://github.com/celo-org/optimism", rev = "b4ba5c3" }

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -155,6 +155,25 @@ where
         ));
     }
 
+    // Bind the committed l2BlockNumber to the actual derived safe-head number. Without this
+    // check, a non-interop EndOfSource that triggers the silent target downgrade in
+    // advance_to_target can let an adversarial witness commit (l2PostRoot, l2BlockNumber)
+    // pairs that refer to different L2 blocks. See https://github.com/succinctlabs/op-succinct/security/advisories/GHSA-5jh4-3p33-85xc.
+    if safe_head.block_info.number != boot.op_boot_info.claimed_l2_block_number {
+        error!(
+            target: "client",
+            derived = safe_head.block_info.number,
+            claimed = boot.op_boot_info.claimed_l2_block_number,
+            "Derived safe head L2 block #{} does not match claimed L2 block number #{}",
+            safe_head.block_info.number,
+            boot.op_boot_info.claimed_l2_block_number,
+        );
+        return Err(FaultProofProgramError::InvalidClaim(
+            output_root,
+            boot.op_boot_info.claimed_l2_output_root,
+        ));
+    }
+
     info!(
         target: "client",
         number = safe_head.block_info.number,

--- a/crates/celo-reth/src/lib.rs
+++ b/crates/celo-reth/src/lib.rs
@@ -3,25 +3,22 @@
 //! Bridges the Celo EVM ([`CeloEvmFactory`]) with reth's node framework,
 //! analogous to `reth-optimism-evm` for vanilla OP Stack chains.
 
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// Most deps in this crate are only used by std-only modules (node, pool,
+// payload, rpc, chainspec) or the binary target. Only warn on unused deps in
+// std builds to avoid spurious warnings under `cargo hack check
+// --no-default-features`.
+#![cfg_attr(all(not(test), feature = "std"), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 
-// These deps are only used by the binary target; declare them here to silence
-// the `unused_crate_dependencies` lint on the library compilation unit.
+// Binary-only deps (used by src/bin/celo_reth.rs but not by the library).
+// Suppress `unused_crate_dependencies` on the std library compilation unit.
 #[cfg(feature = "std")]
-use clap as _;
-#[cfg(feature = "std")]
-use reth_cli_util as _;
-#[cfg(feature = "std")]
-use reth_optimism_cli as _;
-#[cfg(feature = "std")]
-use reth_provider as _;
-#[cfg(feature = "std")]
-use reth_transaction_pool as _;
-#[cfg(feature = "std")]
-use tracing as _;
+use {
+    clap as _, reth_cli_util as _, reth_optimism_cli as _, reth_provider as _,
+    reth_transaction_pool as _, tracing as _,
+};
 
 use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};

--- a/deny.toml
+++ b/deny.toml
@@ -84,10 +84,10 @@ allow-git = [
     "https://github.com/Layr-Labs/hokulea",
     "https://github.com/Layr-Labs/rust-kzg-bn254.git",
     "https://github.com/celo-org/alloy",
-    # kona crates are pulled from the optimism monorepo via the
-    # kona-client/v1.2.13 tag (see 796c67c "point at upstream optimism
-    # kona-client/v1.2.13"), not from celo-org/optimism or op-rs/kona any more.
-    "https://github.com/ethereum-optimism/optimism",
+    # kona crates are pulled from celo-org/optimism fork to include 
+    # https://github.com/ethereum-optimism/optimism/commit/f1930fa and custom max_sequencer_drift
+    # on top of kona-client/v1.2.13.
+    "https://github.com/celo-org/optimism",
 ]
 
 [sources.allow-org]


### PR DESCRIPTION
Optimism published a patch release [kona-client/v1.2.14](https://github.com/ethereum-optimism/optimism/releases/tag/kona-client%2Fv1.2.14) with the security fix for https://github.com/ethereum-optimism/optimism/security/advisories/GHSA-6gcx-mhp9-fxjf. But this release doesn't include the configurable `max_sequencer_drift` yet, so needed to use [our optimism fork with custom `max_sequencer_drift`](https://github.com/celo-org/optimism/commit/b4ba5c397d378eb29c0cd4e0c1fda7d7fdef0b2a). Patched kona and related crates in optimism monorepo.

Also regarding another advisory https://github.com/succinctlabs/op-succinct/security/advisories/GHSA-5jh4-3p33-85xc, mirrors the upstream fix in https://github.com/succinctlabs/op-succinct/commit/5b6119a403e57c904aee7a0339d65f2434a044bc, ported to celo-kona's `single.rs` although it's not directly used in proposer.

Related to https://github.com/celo-org/celo-blockchain-planning/issues/1372
Related to https://github.com/celo-org/celo-blockchain-planning/issues/1384