### PR TITLE
Per evm CIP-64 storage

### DIFF
--- a/crates/alloy-celo-evm/Cargo.toml
+++ b/crates/alloy-celo-evm/Cargo.toml
@@ -17,8 +17,10 @@ celo-alloy-consensus.workspace = true
 
 alloy-evm.workspace = true
 alloy-op-evm = { workspace = true, default-features = false }
+alloy-op-hardforks.workspace = true
 
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 
 op-alloy-consensus.workspace = true
@@ -30,8 +32,6 @@ spin.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-alloy-eips.workspace = true
-alloy-op-hardforks.workspace = true
 # Tests exercise RPC-simulation paths that need to disable the base-fee check.
 revm = { workspace = true, features = ["optional_no_base_fee"] }
 
@@ -43,6 +43,7 @@ std = [
     "alloy-evm/std",
     "op-revm/std",
     "alloy-consensus/std",
+    "alloy-eips/std",
     "op-alloy-consensus/std"
 ]
 # Enables accumulation of every `Cip64ReceiptData` in `Cip64Storage::all_entries`,

--- a/crates/alloy-celo-evm/src/block/executor_factory.rs
+++ b/crates/alloy-celo-evm/src/block/executor_factory.rs
@@ -19,7 +19,6 @@ use alloy_evm::{
 use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutor,
     block::{OpTxResult, receipt_builder::OpReceiptBuilder},
-    post_exec::PostExecEvmFactoryAdapter,
 };
 use alloy_op_hardforks::OpHardforks;
 use celo_revm::{CeloContext, CeloTransaction};
@@ -27,22 +26,16 @@ use op_alloy_consensus::OpTransaction as OpConsensusTransaction;
 use op_revm::OpHaltReason;
 use revm::{Inspector, context::TxEnv};
 
-/// EVM factory used by [`CeloBlockExecutorFactory`]. Wraps [`CeloEvmFactory`] with
-/// [`PostExecEvmFactoryAdapter`] so the resulting EVM satisfies the `PostExecEvm` bound
-/// required by [`OpBlockExecutor`]. Post-exec is unscheduled on Celo; the adapter's hooks
-/// are no-ops (see `PostExecEvmFactoryHooks for CeloEvmFactory` in `alloy-celo-evm`).
-type CeloPostExecFactory = PostExecEvmFactoryAdapter<CeloEvmFactory>;
-
 /// Celo block executor factory.
 ///
 /// Behaves like [`alloy_op_evm::OpBlockExecutorFactory`] but rebuilds `R` per call to
 /// [`create_executor`](BlockExecutorFactory::create_executor) so the receipt builder is always
 /// bound to the EVM's own [`Cip64Storage`]. The `R` type parameter is the runtime receipt
 /// builder used by [`OpBlockExecutor`]; the factory itself never holds an instance of `R`.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CeloBlockExecutorFactory<R, Spec> {
     spec: Spec,
-    evm_factory: CeloPostExecFactory,
+    evm_factory: CeloEvmFactory,
     _phantom: core::marker::PhantomData<fn() -> R>,
 }
 
@@ -58,12 +51,8 @@ impl<R, Spec: Clone> Clone for CeloBlockExecutorFactory<R, Spec> {
 
 impl<R, Spec> CeloBlockExecutorFactory<R, Spec> {
     /// Creates a new factory with the given chain spec and EVM factory.
-    pub fn new(spec: Spec, evm_factory: CeloEvmFactory) -> Self {
-        Self {
-            spec,
-            evm_factory: PostExecEvmFactoryAdapter::new(evm_factory),
-            _phantom: core::marker::PhantomData,
-        }
+    pub const fn new(spec: Spec, evm_factory: CeloEvmFactory) -> Self {
+        Self { spec, evm_factory, _phantom: core::marker::PhantomData }
     }
 
     /// Exposes the chain specification.
@@ -71,8 +60,8 @@ impl<R, Spec> CeloBlockExecutorFactory<R, Spec> {
         &self.spec
     }
 
-    /// Exposes the EVM factory (wrapped in the post-exec adapter).
-    pub const fn evm_factory(&self) -> &CeloPostExecFactory {
+    /// Exposes the EVM factory.
+    pub const fn evm_factory(&self) -> &CeloEvmFactory {
         &self.evm_factory
     }
 }
@@ -82,22 +71,21 @@ where
     R: OpReceiptBuilder<
             Transaction: Transaction + Encodable2718 + OpConsensusTransaction,
             Receipt: TxReceipt,
-        >
-        + From<Cip64Storage>
+        > + From<Cip64Storage>
         + Send
         + Sync
         + 'static,
     Spec: OpHardforks + Clone + Send + Sync + 'static,
     CeloTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
 {
-    type EvmFactory = CeloPostExecFactory;
+    type EvmFactory = CeloEvmFactory;
     type ExecutionCtx<'a> = OpBlockExecutionCtx;
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
     type TxExecutionResult =
         OpTxResult<OpHaltReason, <R::Transaction as TransactionEnvelope>::TxType>;
     type Executor<'a, DB: StateDB, I: Inspector<CeloContext<DB>>> =
-        OpBlockExecutor<<CeloPostExecFactory as EvmFactory>::Evm<DB, I>, R, &'a Spec>;
+        OpBlockExecutor<<CeloEvmFactory as EvmFactory>::Evm<DB, I>, R, &'a Spec>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
@@ -114,8 +102,6 @@ where
     {
         // Bind the receipt builder to the EVM's own CIP-64 storage. The factory holds no
         // long-lived receipt builder or storage handle — both are scoped to this executor.
-        // The post-exec adapter is transparent to `cip64_storage` (accessor passes through
-        // to the inner `CeloEvm`).
         let builder = R::from(evm.cip64_storage().clone());
         OpBlockExecutor::new(evm, ctx, &self.spec, builder)
     }

--- a/crates/alloy-celo-evm/src/block/executor_factory.rs
+++ b/crates/alloy-celo-evm/src/block/executor_factory.rs
@@ -27,16 +27,6 @@ use op_alloy_consensus::OpTransaction as OpConsensusTransaction;
 use op_revm::OpHaltReason;
 use revm::{Inspector, context::TxEnv};
 
-/// Constructor extension for Celo receipt builders.
-///
-/// [`CeloBlockExecutorFactory::create_executor`] re-instantiates the receipt builder once per
-/// block via [`with_cip64_storage`](CeloReceiptBuilderExt::with_cip64_storage), binding it to
-/// the executing EVM's own [`Cip64Storage`].
-pub trait CeloReceiptBuilderExt: OpReceiptBuilder {
-    /// Constructs a fresh builder that reads its CIP-64 receipt data from `storage`.
-    fn with_cip64_storage(storage: Cip64Storage) -> Self;
-}
-
 /// EVM factory used by [`CeloBlockExecutorFactory`]. Wraps [`CeloEvmFactory`] with
 /// [`PostExecEvmFactoryAdapter`] so the resulting EVM satisfies the `PostExecEvm` bound
 /// required by [`OpBlockExecutor`]. Post-exec is unscheduled on Celo; the adapter's hooks
@@ -89,10 +79,12 @@ impl<R, Spec> CeloBlockExecutorFactory<R, Spec> {
 
 impl<R, Spec> BlockExecutorFactory for CeloBlockExecutorFactory<R, Spec>
 where
-    R: CeloReceiptBuilderExt<
+    R: OpReceiptBuilder<
             Transaction: Transaction + Encodable2718 + OpConsensusTransaction,
             Receipt: TxReceipt,
-        > + Send
+        >
+        + From<Cip64Storage>
+        + Send
         + Sync
         + 'static,
     Spec: OpHardforks + Clone + Send + Sync + 'static,
@@ -124,8 +116,7 @@ where
         // long-lived receipt builder or storage handle — both are scoped to this executor.
         // The post-exec adapter is transparent to `cip64_storage` (accessor passes through
         // to the inner `CeloEvm`).
-        let storage = evm.cip64_storage().clone();
-        let builder = R::with_cip64_storage(storage);
+        let builder = R::from(evm.cip64_storage().clone());
         OpBlockExecutor::new(evm, ctx, &self.spec, builder)
     }
 }

--- a/crates/alloy-celo-evm/src/block/executor_factory.rs
+++ b/crates/alloy-celo-evm/src/block/executor_factory.rs
@@ -1,0 +1,131 @@
+//! Celo block executor factory.
+//!
+//! This factory is the per-block bridge between a [`CeloEvm`](crate::CeloEvm)'s own
+//! [`Cip64Storage`] and the receipt builder that will consume it. Each
+//! [`CeloEvm`](crate::CeloEvm) produced by a [`CeloEvmFactory`] owns a fresh [`Cip64Storage`],
+//! and on every call to [`create_executor`](BlockExecutorFactory::create_executor) we
+//! construct a *new* receipt builder bound to that storage. The factory itself holds no
+//! long-lived storage handle, so two consumers running through the same [`CeloEvmFactory`]
+//! (e.g. the main-chain block executor and a re-executing ExEx) cannot interfere with each
+//! other's pending CIP-64 receipt data.
+
+use crate::{CeloEvmFactory, cip64_storage::Cip64Storage};
+use alloy_consensus::{Transaction, TransactionEnvelope, TxReceipt};
+use alloy_eips::Encodable2718;
+use alloy_evm::{
+    EvmFactory, FromRecoveredTx, FromTxWithEncoded,
+    block::{BlockExecutorFactory, StateDB},
+};
+use alloy_op_evm::{
+    OpBlockExecutionCtx, OpBlockExecutor,
+    block::{OpTxResult, receipt_builder::OpReceiptBuilder},
+    post_exec::PostExecEvmFactoryAdapter,
+};
+use alloy_op_hardforks::OpHardforks;
+use celo_revm::{CeloContext, CeloTransaction};
+use op_alloy_consensus::OpTransaction as OpConsensusTransaction;
+use op_revm::OpHaltReason;
+use revm::{Inspector, context::TxEnv};
+
+/// Constructor extension for Celo receipt builders.
+///
+/// [`CeloBlockExecutorFactory::create_executor`] re-instantiates the receipt builder once per
+/// block via [`with_cip64_storage`](CeloReceiptBuilderExt::with_cip64_storage), binding it to
+/// the executing EVM's own [`Cip64Storage`].
+pub trait CeloReceiptBuilderExt: OpReceiptBuilder {
+    /// Constructs a fresh builder that reads its CIP-64 receipt data from `storage`.
+    fn with_cip64_storage(storage: Cip64Storage) -> Self;
+}
+
+/// EVM factory used by [`CeloBlockExecutorFactory`]. Wraps [`CeloEvmFactory`] with
+/// [`PostExecEvmFactoryAdapter`] so the resulting EVM satisfies the `PostExecEvm` bound
+/// required by [`OpBlockExecutor`]. Post-exec is unscheduled on Celo; the adapter's hooks
+/// are no-ops (see `PostExecEvmFactoryHooks for CeloEvmFactory` in `alloy-celo-evm`).
+type CeloPostExecFactory = PostExecEvmFactoryAdapter<CeloEvmFactory>;
+
+/// Celo block executor factory.
+///
+/// Behaves like [`alloy_op_evm::OpBlockExecutorFactory`] but rebuilds `R` per call to
+/// [`create_executor`](BlockExecutorFactory::create_executor) so the receipt builder is always
+/// bound to the EVM's own [`Cip64Storage`]. The `R` type parameter is the runtime receipt
+/// builder used by [`OpBlockExecutor`]; the factory itself never holds an instance of `R`.
+#[derive(Debug)]
+pub struct CeloBlockExecutorFactory<R, Spec> {
+    spec: Spec,
+    evm_factory: CeloPostExecFactory,
+    _phantom: core::marker::PhantomData<fn() -> R>,
+}
+
+impl<R, Spec: Clone> Clone for CeloBlockExecutorFactory<R, Spec> {
+    fn clone(&self) -> Self {
+        Self {
+            spec: self.spec.clone(),
+            evm_factory: self.evm_factory.clone(),
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<R, Spec> CeloBlockExecutorFactory<R, Spec> {
+    /// Creates a new factory with the given chain spec and EVM factory.
+    pub fn new(spec: Spec, evm_factory: CeloEvmFactory) -> Self {
+        Self {
+            spec,
+            evm_factory: PostExecEvmFactoryAdapter::new(evm_factory),
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Exposes the chain specification.
+    pub const fn spec(&self) -> &Spec {
+        &self.spec
+    }
+
+    /// Exposes the EVM factory (wrapped in the post-exec adapter).
+    pub const fn evm_factory(&self) -> &CeloPostExecFactory {
+        &self.evm_factory
+    }
+}
+
+impl<R, Spec> BlockExecutorFactory for CeloBlockExecutorFactory<R, Spec>
+where
+    R: CeloReceiptBuilderExt<
+            Transaction: Transaction + Encodable2718 + OpConsensusTransaction,
+            Receipt: TxReceipt,
+        > + Send
+        + Sync
+        + 'static,
+    Spec: OpHardforks + Clone + Send + Sync + 'static,
+    CeloTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+{
+    type EvmFactory = CeloPostExecFactory;
+    type ExecutionCtx<'a> = OpBlockExecutionCtx;
+    type Transaction = R::Transaction;
+    type Receipt = R::Receipt;
+    type TxExecutionResult =
+        OpTxResult<OpHaltReason, <R::Transaction as TransactionEnvelope>::TxType>;
+    type Executor<'a, DB: StateDB, I: Inspector<CeloContext<DB>>> =
+        OpBlockExecutor<<CeloPostExecFactory as EvmFactory>::Evm<DB, I>, R, &'a Spec>;
+
+    fn evm_factory(&self) -> &Self::EvmFactory {
+        &self.evm_factory
+    }
+
+    fn create_executor<'a, DB, I>(
+        &'a self,
+        evm: <Self::EvmFactory as EvmFactory>::Evm<DB, I>,
+        ctx: Self::ExecutionCtx<'a>,
+    ) -> Self::Executor<'a, DB, I>
+    where
+        DB: StateDB,
+        I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>,
+    {
+        // Bind the receipt builder to the EVM's own CIP-64 storage. The factory holds no
+        // long-lived receipt builder or storage handle — both are scoped to this executor.
+        // The post-exec adapter is transparent to `cip64_storage` (accessor passes through
+        // to the inner `CeloEvm`).
+        let storage = evm.cip64_storage().clone();
+        let builder = R::with_cip64_storage(storage);
+        OpBlockExecutor::new(evm, ctx, &self.spec, builder)
+    }
+}

--- a/crates/alloy-celo-evm/src/block/mod.rs
+++ b/crates/alloy-celo-evm/src/block/mod.rs
@@ -1,6 +1,6 @@
 //! Block executor for Celo.
 
-pub use executor_factory::{CeloBlockExecutorFactory, CeloReceiptBuilderExt};
+pub use executor_factory::CeloBlockExecutorFactory;
 pub use receipt_builder::CeloAlloyReceiptBuilder;
 
 pub mod executor_factory;

--- a/crates/alloy-celo-evm/src/block/mod.rs
+++ b/crates/alloy-celo-evm/src/block/mod.rs
@@ -1,7 +1,9 @@
 //! Block executor for Celo.
 
+pub use executor_factory::{CeloBlockExecutorFactory, CeloReceiptBuilderExt};
 pub use receipt_builder::CeloAlloyReceiptBuilder;
 
+pub mod executor_factory;
 pub mod receipt_builder;
 
 #[cfg(test)]

--- a/crates/alloy-celo-evm/src/block/mod.rs
+++ b/crates/alloy-celo-evm/src/block/mod.rs
@@ -16,9 +16,7 @@ mod tests {
         EvmEnv, EvmFactory,
         block::{BlockExecutor, BlockExecutorFactory},
     };
-    use alloy_op_evm::{
-        OpBlockExecutionCtx, OpBlockExecutorFactory, post_exec::PostExecEvmFactoryAdapter,
-    };
+    use alloy_op_evm::OpBlockExecutionCtx;
     use alloy_op_hardforks::OpChainHardforks;
     use alloy_primitives::{Address, Signature};
     use celo_alloy_consensus::CeloTxEnvelope;
@@ -26,10 +24,9 @@ mod tests {
 
     #[test]
     fn test_with_encoded() {
-        let executor_factory = OpBlockExecutorFactory::new(
-            CeloAlloyReceiptBuilder::default(),
+        let executor_factory = CeloBlockExecutorFactory::<CeloAlloyReceiptBuilder, _>::new(
             OpChainHardforks::op_mainnet(),
-            PostExecEvmFactoryAdapter::new(CeloEvmFactory::default()),
+            CeloEvmFactory::default(),
         );
         let mut db = State::builder().with_database(CacheDB::<EmptyDB>::default()).build();
         let evm = executor_factory.evm_factory().create_evm(&mut db, EvmEnv::default());

--- a/crates/alloy-celo-evm/src/block/receipt_builder.rs
+++ b/crates/alloy-celo-evm/src/block/receipt_builder.rs
@@ -8,13 +8,18 @@ use celo_alloy_consensus::{CeloCip64Receipt, CeloReceiptEnvelope, CeloTxEnvelope
 use core::fmt::Debug;
 use op_alloy_consensus::OpDepositReceipt;
 
-use crate::cip64_storage::Cip64Storage;
+use crate::{block::executor_factory::CeloReceiptBuilderExt, cip64_storage::Cip64Storage};
 
 /// Receipt builder operating on celo-alloy types.
+///
+/// Holds the [`Cip64Storage`] handle bound to the executing [`CeloEvm`](crate::CeloEvm) for
+/// this block. The handle is set once per block by
+/// [`CeloBlockExecutorFactory`](crate::block::CeloBlockExecutorFactory) — the builder is never
+/// long-lived across executors, so it never accumulates state from past blocks.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct CeloAlloyReceiptBuilder {
-    /// Storage for CIP-64 transaction execution results
+    /// Storage for CIP-64 transaction execution results, scoped to one block executor.
     pub cip64_storage: Cip64Storage,
 }
 
@@ -22,6 +27,12 @@ impl CeloAlloyReceiptBuilder {
     /// Creates a new receipt builder with the given CIP-64 storage
     pub const fn new(cip64_storage: Cip64Storage) -> Self {
         Self { cip64_storage }
+    }
+}
+
+impl CeloReceiptBuilderExt for CeloAlloyReceiptBuilder {
+    fn with_cip64_storage(storage: Cip64Storage) -> Self {
+        Self::new(storage)
     }
 }
 

--- a/crates/alloy-celo-evm/src/block/receipt_builder.rs
+++ b/crates/alloy-celo-evm/src/block/receipt_builder.rs
@@ -20,7 +20,7 @@ use crate::cip64_storage::Cip64Storage;
 #[non_exhaustive]
 pub struct CeloAlloyReceiptBuilder {
     /// Storage for CIP-64 transaction execution results, scoped to one block executor.
-    pub cip64_storage: Cip64Storage,
+    pub(crate) cip64_storage: Cip64Storage,
 }
 
 impl CeloAlloyReceiptBuilder {

--- a/crates/alloy-celo-evm/src/block/receipt_builder.rs
+++ b/crates/alloy-celo-evm/src/block/receipt_builder.rs
@@ -8,7 +8,7 @@ use celo_alloy_consensus::{CeloCip64Receipt, CeloReceiptEnvelope, CeloTxEnvelope
 use core::fmt::Debug;
 use op_alloy_consensus::OpDepositReceipt;
 
-use crate::{block::executor_factory::CeloReceiptBuilderExt, cip64_storage::Cip64Storage};
+use crate::cip64_storage::Cip64Storage;
 
 /// Receipt builder operating on celo-alloy types.
 ///
@@ -30,9 +30,9 @@ impl CeloAlloyReceiptBuilder {
     }
 }
 
-impl CeloReceiptBuilderExt for CeloAlloyReceiptBuilder {
-    fn with_cip64_storage(storage: Cip64Storage) -> Self {
-        Self::new(storage)
+impl From<Cip64Storage> for CeloAlloyReceiptBuilder {
+    fn from(cip64_storage: Cip64Storage) -> Self {
+        Self::new(cip64_storage)
     }
 }
 

--- a/crates/alloy-celo-evm/src/block/receipt_builder.rs
+++ b/crates/alloy-celo-evm/src/block/receipt_builder.rs
@@ -51,6 +51,10 @@ impl OpReceiptBuilder for CeloAlloyReceiptBuilder {
 
                 // Pop the CIP-64 receipt data stored during transact_raw
                 let cip64_data = self.cip64_storage.pop_cip64_receipt_data();
+                assert!(
+                    cip64_data.is_some() || !success,
+                    "CIP-64 tx succeeded but no receipt data was stored — transact_raw invariant violated"
+                );
                 let base_fee_in_erc20 =
                     cip64_data.as_ref().and_then(|d| d.cip64_info.base_fee_in_erc20);
 

--- a/crates/alloy-celo-evm/src/blocklist.rs
+++ b/crates/alloy-celo-evm/src/blocklist.rs
@@ -6,8 +6,8 @@
 //!
 //! This lives in `alloy-celo-evm` (not `celo-reth`) because it is checked inside
 //! `CeloEvm::transact_raw()` — the shared execution path used by both reth and any other
-//! consumer of `CeloEvmFactory`. Kona/ZK paths do not need it and pass `blocklist: None`
-//! when constructing `CeloEvmFactory::default()`.
+//! consumer of `CeloEvmFactory`. Kona/ZK paths do not need it and use the default empty
+//! blocklist on `CeloEvmFactory::default()`.
 //!
 //! Blocklisting can be controlled per-currency via admin RPCs:
 //! - `admin_disableBlocklistFeeCurrencies`: Prevents a currency from being blocklisted.

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -490,16 +490,21 @@ impl EvmFactory for CeloEvmFactory {
 // SDM/post-exec is unscheduled on Celo: `RollupConfig::is_sdm_active` is hard-wired to `false`
 // upstream, and Celo has no plans to activate it. This impl exists only so `CeloEvm` satisfies
 // the `PostExecEvm` bound that `OpBlockExecutor: BlockExecutor` requires (mirroring the direct
-// `PostExecEvm for OpEvm` impl in alloy-op-evm). The methods should never be called in practice.
+// `PostExecEvm for OpEvm` impl in alloy-op-evm).
+//
+// Both methods panic: if SDM is ever activated on Celo (e.g. via an upstream rebase), the
+// panic surfaces the gap immediately rather than silently returning a default value.
 impl<DB, I, P> PostExecEvm for CeloEvm<DB, I, P>
 where
     DB: Database,
     Self: Evm,
 {
-    fn begin_post_exec_tx(&mut self, _ctx: PostExecTxContext) {}
+    fn begin_post_exec_tx(&mut self, _ctx: PostExecTxContext) {
+        panic!("SDM unscheduled on Celo — `RollupConfig::is_sdm_active` must remain false");
+    }
 
     fn take_last_post_exec_tx_result(&mut self) -> PostExecExecutedTx {
-        PostExecExecutedTx::default()
+        panic!("SDM unscheduled on Celo — `RollupConfig::is_sdm_active` must remain false");
     }
 }
 

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -387,22 +387,19 @@ where
 }
 
 /// Factory producing [`CeloEvm`]s.
+///
+/// Each EVM produced by this factory carries its own fresh [`Cip64Storage`]: the storage
+/// is owned by the EVM instance, not the factory, so two consumers (e.g. the main-chain
+/// executor and a re-executing ExEx) running through the same factory get independent
+/// slots and never overwrite each other's pending CIP-64 receipt data.
 #[derive(Debug, Default, Clone)]
 pub struct CeloEvmFactory {
-    /// Shared CIP-64 storage. When set, all EVMs created by this factory will use this
-    /// storage instance, enabling the receipt builder to read CIP-64 data written by the EVM.
-    pub cip64_storage: Option<Cip64Storage>,
     /// Shared fee currency blocklist. When set, all EVMs created by this factory will use
     /// this blocklist to reject CIP-64 transactions for blocklisted currencies.
     pub blocklist: Option<FeeCurrencyBlocklist>,
 }
 
 impl CeloEvmFactory {
-    /// Creates a new factory with shared CIP-64 storage.
-    pub const fn with_cip64_storage(cip64_storage: Cip64Storage) -> Self {
-        Self { cip64_storage: Some(cip64_storage), blocklist: None }
-    }
-
     /// Sets the shared fee currency blocklist.
     pub fn with_blocklist(mut self, blocklist: FeeCurrencyBlocklist) -> Self {
         self.blocklist = Some(blocklist);
@@ -453,7 +450,7 @@ impl CeloEvmFactory {
                 .build_celo_with_inspector(inspector)
                 .with_precompiles(celo_precompiles_map(spec_id)),
             inspect,
-            cip64_storage: self.cip64_storage.clone().unwrap_or_default(),
+            cip64_storage: Cip64Storage::default(),
             blocklist: self.blocklist.clone().unwrap_or_default(),
             last_evicted_timestamp: 0,
         }
@@ -668,6 +665,51 @@ mod tests {
         assert!(
             evm.cip64_storage.pop_cip64_receipt_data().is_none(),
             "RPC simulation must not store CIP-64 receipt data"
+        );
+    }
+
+    /// #172's slot-occupied assertion is a *per-EVM* invariant: a single
+    /// [`CeloEvm`] never sees two `store_cip64_info` calls without an intervening
+    /// `pop_cip64_receipt_data`. Verify the panic still fires when an executor
+    /// runs two CIP-64 transactions back-to-back without a receipt build in
+    /// between (i.e. the original #172 bug class).
+    #[test]
+    #[should_panic(expected = "store_cip64_info called with slot occupied")]
+    fn double_store_on_same_evm_panics() {
+        let evm = make_test_evm(FeeCurrencyBlocklist::default());
+        // We push to the EVM's own storage directly rather than driving two real
+        // `transact_raw` calls, which would require a complete fee-currency setup
+        // in the in-memory database. The invariant under test is purely the
+        // single-slot guarantee on the storage itself, scoped to one EVM.
+        evm.cip64_storage().store_cip64_info(None, celo_revm::Cip64Info::default());
+        evm.cip64_storage().store_cip64_info(None, celo_revm::Cip64Info::default());
+    }
+
+    /// Two [`CeloEvm`] instances produced by the same [`CeloEvmFactory`] must own
+    /// independent [`Cip64Storage`] slots. This is the regression for #183: when
+    /// the proofs-history ExEx re-executes blocks through the same factory, its
+    /// EVM's CIP-64 writes must not bleed into the main-chain executor's storage.
+    #[test]
+    fn two_evms_from_same_factory_have_independent_slots() {
+        let factory = CeloEvmFactory::default();
+        let db_a = revm::database::InMemoryDB::default();
+        let db_b = revm::database::InMemoryDB::default();
+        let env = EvmEnv::<OpSpecId>::default();
+        let evm_a = factory.create_evm(db_a, env.clone());
+        let evm_b = factory.create_evm(db_b, env);
+
+        // Push to A only.
+        evm_a.cip64_storage().store_cip64_info(None, celo_revm::Cip64Info::default());
+
+        // B's slot is untouched.
+        assert!(
+            evm_b.cip64_storage().pop_cip64_receipt_data().is_none(),
+            "second EVM's slot must be empty — factory must not share storage between EVMs"
+        );
+        // A's slot still has the entry.
+        assert!(
+            evm_a.cip64_storage().pop_cip64_receipt_data().is_some(),
+            "first EVM's slot must still hold its own entry"
         );
     }
 

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -394,15 +394,15 @@ where
 /// slots and never overwrite each other's pending CIP-64 receipt data.
 #[derive(Debug, Default, Clone)]
 pub struct CeloEvmFactory {
-    /// Shared fee currency blocklist. When set, all EVMs created by this factory will use
-    /// this blocklist to reject CIP-64 transactions for blocklisted currencies.
-    pub blocklist: Option<FeeCurrencyBlocklist>,
+    /// Shared fee currency blocklist. All EVMs created by this factory use this blocklist
+    /// to reject CIP-64 transactions for blocklisted currencies. Defaults to empty.
+    pub blocklist: FeeCurrencyBlocklist,
 }
 
 impl CeloEvmFactory {
     /// Sets the shared fee currency blocklist.
     pub fn with_blocklist(mut self, blocklist: FeeCurrencyBlocklist) -> Self {
-        self.blocklist = Some(blocklist);
+        self.blocklist = blocklist;
         self
     }
 }
@@ -451,7 +451,7 @@ impl CeloEvmFactory {
                 .with_precompiles(celo_precompiles_map(spec_id)),
             inspect,
             cip64_storage: Cip64Storage::default(),
-            blocklist: self.blocklist.clone().unwrap_or_default(),
+            blocklist: self.blocklist.clone(),
             last_evicted_timestamp: 0,
         }
     }
@@ -666,23 +666,6 @@ mod tests {
             evm.cip64_storage.pop_cip64_receipt_data().is_none(),
             "RPC simulation must not store CIP-64 receipt data"
         );
-    }
-
-    /// #172's slot-occupied assertion is a *per-EVM* invariant: a single
-    /// [`CeloEvm`] never sees two `store_cip64_info` calls without an intervening
-    /// `pop_cip64_receipt_data`. Verify the panic still fires when an executor
-    /// runs two CIP-64 transactions back-to-back without a receipt build in
-    /// between (i.e. the original #172 bug class).
-    #[test]
-    #[should_panic(expected = "store_cip64_info called with slot occupied")]
-    fn double_store_on_same_evm_panics() {
-        let evm = make_test_evm(FeeCurrencyBlocklist::default());
-        // We push to the EVM's own storage directly rather than driving two real
-        // `transact_raw` calls, which would require a complete fee-currency setup
-        // in the in-memory database. The invariant under test is purely the
-        // single-slot guarantee on the storage itself, scoped to one EVM.
-        evm.cip64_storage().store_cip64_info(None, celo_revm::Cip64Info::default());
-        evm.cip64_storage().store_cip64_info(None, celo_revm::Cip64Info::default());
     }
 
     /// Two [`CeloEvm`] instances produced by the same [`CeloEvmFactory`] must own

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -299,10 +299,12 @@ where
                 // CIP64 NOTE:
                 // Extract and store the cip64 info to a shared storage to be able to add the
                 // credit/debit logs when building the receipt in the receipts_builder.
-                // Only store during block building: RPC simulation paths (eth_call,
-                // eth_estimateGas) never drain the slot, so a stale entry would be picked up
-                // by the next real block's first CIP-64 tx and corrupt its receipt (or trip
-                // the slot-occupied assertion in `store_cip64_info`).
+                // Only store during block building: storage is per-EVM (so cross-EVM
+                // pollution is impossible), but multi-tx RPC tracing (`debug_traceBlock`,
+                // `debug_traceTransaction`) re-executes multiple txs through one EVM
+                // without calling `build_receipt`. Skipping the store here keeps the
+                // slot-occupied panic in `store_cip64_info` a signal of a real executor
+                // bug instead of firing on legitimate RPC paths.
                 let cip64_info = self.inner.inner.0.ctx.tx.cip64_tx_info.take();
                 if is_block_building && let Some(cip64_info) = cip64_info {
                     self.cip64_storage.store_cip64_info(fee_currency, cip64_info);
@@ -627,17 +629,19 @@ mod tests {
         assert!(!blocklist.is_blocked(fc), "Non-debit/credit error should not cause blocklisting");
     }
 
-    /// Verify that RPC simulation paths (eth_call / eth_estimateGas) never
-    /// store CIP-64 receipt data. The receipt builder only runs during real
-    /// block execution, so any entry left here would be picked up by the next
-    /// real block's first CIP-64 tx and corrupt its receipt (or trip the
-    /// slot-occupied assertion in `store_cip64_info`).
+    /// Verify that RPC simulation paths (eth_call / eth_estimateGas / debug_trace*)
+    /// never store CIP-64 receipt data. Storage is per-EVM, so cross-EVM
+    /// corruption is impossible — but multi-tx tracing (`debug_traceBlock`,
+    /// `debug_traceTransaction`) re-executes multiple txs through one EVM
+    /// without calling `build_receipt`. Without the `is_block_building` gate
+    /// in `transact_raw`, the second CIP-64 tx would trip the slot-occupied
+    /// panic in `store_cip64_info` on perfectly legitimate RPC paths.
     ///
     /// The handler still populates `cip64_tx_info` during simulation for
     /// native-fee CIP-64 txs (`feeCurrency == 0x0`), so this guard lives in
     /// `transact_raw`, not the handler.
     #[test]
-    fn test_cip64_storage_not_polluted_by_rpc_simulation() {
+    fn test_cip64_info_not_stored_during_rpc_simulation() {
         use revm::state::AccountInfo;
 
         let blocklist = FeeCurrencyBlocklist::default();

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
 };
 use alloy_op_evm::{
     OpTxError, map_op_err,
-    post_exec::{PostExecEvmFactoryHooks, PostExecExecutedTx, PostExecTxContext},
+    post_exec::{PostExecEvm, PostExecExecutedTx, PostExecTxContext},
 };
 use alloy_primitives::{Address, Bytes, U256};
 use celo_revm::{
@@ -488,22 +488,17 @@ impl EvmFactory for CeloEvmFactory {
 }
 
 // SDM/post-exec is unscheduled on Celo: `RollupConfig::is_sdm_active` is hard-wired to `false`
-// upstream, and Celo has no plans to activate it. These hooks are wired up so that
-// `CeloEvmFactory` can be wrapped in `PostExecEvmFactoryAdapter` and satisfy the
-// `BlockExecutorFactory` impl in alloy-op-evm 0.32, but they should never be called in practice.
-impl PostExecEvmFactoryHooks for CeloEvmFactory {
-    fn begin_post_exec_tx<DB, I>(_evm: &mut Self::Evm<DB, I>, _ctx: PostExecTxContext)
-    where
-        DB: Database,
-        I: Inspector<Self::Context<DB>>,
-    {
-    }
+// upstream, and Celo has no plans to activate it. This impl exists only so `CeloEvm` satisfies
+// the `PostExecEvm` bound that `OpBlockExecutor: BlockExecutor` requires (mirroring the direct
+// `PostExecEvm for OpEvm` impl in alloy-op-evm). The methods should never be called in practice.
+impl<DB, I, P> PostExecEvm for CeloEvm<DB, I, P>
+where
+    DB: Database,
+    Self: Evm,
+{
+    fn begin_post_exec_tx(&mut self, _ctx: PostExecTxContext) {}
 
-    fn take_last_post_exec_tx_result<DB, I>(_evm: &mut Self::Evm<DB, I>) -> PostExecExecutedTx
-    where
-        DB: Database,
-        I: Inspector<Self::Context<DB>>,
-    {
+    fn take_last_post_exec_tx_result(&mut self) -> PostExecExecutedTx {
         PostExecExecutedTx::default()
     }
 }

--- a/crates/celo-reth/src/lib.rs
+++ b/crates/celo-reth/src/lib.rs
@@ -210,7 +210,7 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    R: alloy_celo_evm::block::CeloReceiptBuilderExt
+    R: From<alloy_celo_evm::cip64_storage::Cip64Storage>
         + OpReceiptBuilder<
             Receipt: DepositReceipt,
             Transaction: SignedTransaction
@@ -304,7 +304,7 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    R: alloy_celo_evm::block::CeloReceiptBuilderExt
+    R: From<alloy_celo_evm::cip64_storage::Cip64Storage>
         + OpReceiptBuilder<
             Receipt: DepositReceipt,
             Transaction: SignedTransaction
@@ -335,7 +335,7 @@ where
         let evm = self.evm_for_block(db, block.header())?;
         let ctx = self.context_for_block_with_post_exec_mode(block, Some(post_exec_mode));
         // Bind a fresh receipt builder to this EVM's per-instance CIP-64 storage.
-        let builder = R::with_cip64_storage(evm.cip64_storage().clone());
+        let builder = R::from(evm.cip64_storage().clone());
 
         Ok(OpBlockExecutor::new(evm, ctx, self.executor_factory.spec(), builder))
     }
@@ -354,7 +354,7 @@ where
         let evm = self.evm_with_env(db, evm_env);
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);
-        let builder = R::with_cip64_storage(evm.cip64_storage().clone());
+        let builder = R::from(evm.cip64_storage().clone());
         let executor = OpBlockExecutor::new(evm, ctx.clone(), self.executor_factory.spec(), builder);
 
         Ok(BasicBlockBuilder::<'a, CeloBlockExecutorFactory<R, Arc<ChainSpec>>, _, _, N> {
@@ -378,7 +378,7 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    R: alloy_celo_evm::block::CeloReceiptBuilderExt
+    R: From<alloy_celo_evm::cip64_storage::Cip64Storage>
         + OpReceiptBuilder<
             Receipt: DepositReceipt,
             Transaction: SignedTransaction

--- a/crates/celo-reth/src/lib.rs
+++ b/crates/celo-reth/src/lib.rs
@@ -355,7 +355,8 @@ where
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);
         let builder = R::from(evm.cip64_storage().clone());
-        let executor = OpBlockExecutor::new(evm, ctx.clone(), self.executor_factory.spec(), builder);
+        let executor =
+            OpBlockExecutor::new(evm, ctx.clone(), self.executor_factory.spec(), builder);
 
         Ok(BasicBlockBuilder::<'a, CeloBlockExecutorFactory<R, Arc<ChainSpec>>, _, _, N> {
             executor,

--- a/crates/celo-reth/src/lib.rs
+++ b/crates/celo-reth/src/lib.rs
@@ -22,12 +22,8 @@ use {
 
 use alloc::sync::Arc;
 use alloy_consensus::{BlockHeader, Header};
-use alloy_evm::{
-    EvmFactory, FromRecoveredTx, FromTxWithEncoded, TransactionEnvMut as TransactionEnv,
-    block::BlockExecutorFactory, precompiles::PrecompilesMap,
-};
-use alloy_op_evm::block::{OpTxEnv, receipt_builder::OpReceiptBuilder};
-use core::fmt::Debug;
+use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
+use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
 use op_alloy_consensus::EIP1559ParamError;
 use op_revm::OpSpecId;
 use reth_chainspec::EthChainSpec;
@@ -39,7 +35,6 @@ use reth_evm::{
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_primitives_traits::{NodePrimitives, SealedBlock, SealedHeader, SignedTransaction};
-use revm::context::BlockEnv;
 
 pub mod primitives;
 pub mod receipt;
@@ -72,18 +67,14 @@ pub use receipt::CeloReceipt;
 pub use receipts::CeloRethReceiptBuilder;
 
 // Re-export block assembler and execution context from op-reth (same for Celo as OP Stack).
-pub use alloy_op_evm::{
-    OpBlockExecutor,
-    post_exec::{PostExecEvmFactoryHooks, PostExecExecutorExt},
-};
+pub use alloy_op_evm::{OpBlockExecutor, post_exec::PostExecExecutorExt};
 pub use reth_optimism_evm::{
-    ConfigurePostExecEvm, OpBlockAssembler, OpBlockExecutionCtx, OpBlockExecutorFactory,
-    OpNextBlockEnvAttributes, PostExecMode, l1,
+    ConfigurePostExecEvm, OpBlockAssembler, OpBlockExecutionCtx, OpNextBlockEnvAttributes,
+    PostExecMode, l1,
 };
 
 // Re-export Celo EVM types.
-pub use alloy_celo_evm::{CeloEvm, CeloEvmFactory};
-pub use alloy_op_evm::post_exec::PostExecEvmFactoryAdapter;
+pub use alloy_celo_evm::{CeloEvm, CeloEvmFactory, block::CeloBlockExecutorFactory};
 
 use reth_optimism_primitives::DepositReceipt;
 
@@ -123,19 +114,17 @@ pub struct CeloEvmConfig<
     ChainSpec = OpChainSpec,
     N: NodePrimitives = CeloPrimitives,
     R = CeloRethReceiptBuilder,
-    EvmFactory = PostExecEvmFactoryAdapter<CeloEvmFactory>,
 > {
-    /// Inner [`OpBlockExecutorFactory`].
-    pub executor_factory: OpBlockExecutorFactory<R, Arc<ChainSpec>, EvmFactory>,
+    /// Inner [`CeloBlockExecutorFactory`]. Constructs a fresh receipt builder bound to the
+    /// EVM's own CIP-64 storage on every `create_executor` call.
+    pub executor_factory: CeloBlockExecutorFactory<R, Arc<ChainSpec>>,
     /// Block assembler (shared with OP Stack).
     pub block_assembler: OpBlockAssembler<ChainSpec>,
     #[doc(hidden)]
     pub _pd: core::marker::PhantomData<N>,
 }
 
-impl<ChainSpec, N: NodePrimitives, R: Clone, EvmFactory: Clone> Clone
-    for CeloEvmConfig<ChainSpec, N, R, EvmFactory>
-{
+impl<ChainSpec, N: NodePrimitives, R> Clone for CeloEvmConfig<ChainSpec, N, R> {
     fn clone(&self) -> Self {
         Self {
             executor_factory: self.executor_factory.clone(),
@@ -159,24 +148,19 @@ impl<ChainSpec: OpHardforks> CeloEvmConfig<ChainSpec> {
         chain_spec: Arc<ChainSpec>,
         blocklist: alloy_celo_evm::blocklist::FeeCurrencyBlocklist,
     ) -> Self {
-        // Create a shared CIP-64 storage so the EVM and receipt builder can communicate.
-        let cip64_storage = alloy_celo_evm::cip64_storage::Cip64Storage::default();
-        let receipt_builder = CeloRethReceiptBuilder::new(cip64_storage.clone());
-        let evm_factory =
-            CeloEvmFactory::with_cip64_storage(cip64_storage).with_blocklist(blocklist);
+        // No shared CIP-64 storage here: each `CeloEvm` produced by the factory owns its own,
+        // and the executor factory re-binds the receipt builder to that per-EVM storage on
+        // every `create_executor` call.
+        let evm_factory = CeloEvmFactory::default().with_blocklist(blocklist);
         Self {
             block_assembler: OpBlockAssembler::new(chain_spec.clone()),
-            executor_factory: OpBlockExecutorFactory::new(
-                receipt_builder,
-                chain_spec,
-                PostExecEvmFactoryAdapter::new(evm_factory),
-            ),
+            executor_factory: CeloBlockExecutorFactory::new(chain_spec, evm_factory),
             _pd: core::marker::PhantomData,
         }
     }
 }
 
-impl<ChainSpec, N, R, EvmFactory> CeloEvmConfig<ChainSpec, N, R, EvmFactory>
+impl<ChainSpec, N, R> CeloEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: OpHardforks,
     N: NodePrimitives,
@@ -216,7 +200,7 @@ where
     }
 }
 
-impl<ChainSpec, N, R, EvmF> ConfigureEvm for CeloEvmConfig<ChainSpec, N, R, EvmF>
+impl<ChainSpec, N, R> ConfigureEvm for CeloEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: EthChainSpec<Header = Header> + OpHardforks,
     N: NodePrimitives<
@@ -226,28 +210,23 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
-    EvmF: EvmFactory<
-            Tx: FromRecoveredTx<R::Transaction>
-                    + FromTxWithEncoded<R::Transaction>
-                    + TransactionEnv
-                    + OpTxEnv,
-            Spec = OpSpecId,
-            BlockEnv = BlockEnv,
-            Precompiles = PrecompilesMap,
-        > + Debug,
-    OpBlockExecutorFactory<R, Arc<ChainSpec>, EvmF>: for<'a> BlockExecutorFactory<
-            EvmFactory = EvmF,
-            ExecutionCtx<'a> = OpBlockExecutionCtx,
-            Transaction = R::Transaction,
-            Receipt = R::Receipt,
-        >,
+    R: alloy_celo_evm::block::CeloReceiptBuilderExt
+        + OpReceiptBuilder<
+            Receipt: DepositReceipt,
+            Transaction: SignedTransaction
+                             + alloy_consensus::Transaction
+                             + op_alloy_consensus::OpTransaction,
+        > + Send
+        + Sync
+        + 'static,
+    celo_revm::CeloTransaction<revm::context::TxEnv>:
+        FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Self: Send + Sync + Unpin + Clone + 'static,
 {
     type Primitives = N;
     type Error = EIP1559ParamError;
     type NextBlockEnvCtx = OpNextBlockEnvAttributes;
-    type BlockExecutorFactory = OpBlockExecutorFactory<R, Arc<ChainSpec>, EvmF>;
+    type BlockExecutorFactory = CeloBlockExecutorFactory<R, Arc<ChainSpec>>;
     type BlockAssembler = OpBlockAssembler<ChainSpec>;
 
     fn block_executor_factory(&self) -> &Self::BlockExecutorFactory {
@@ -315,8 +294,7 @@ where
     }
 }
 
-impl<ChainSpec, N, R, F> ConfigurePostExecEvm
-    for CeloEvmConfig<ChainSpec, N, R, PostExecEvmFactoryAdapter<F>>
+impl<ChainSpec, N, R> ConfigurePostExecEvm for CeloEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: EthChainSpec<Header = Header> + OpHardforks + Send + Sync + Unpin + 'static,
     N: NodePrimitives<
@@ -326,28 +304,19 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    R: OpReceiptBuilder<
+    R: alloy_celo_evm::block::CeloReceiptBuilderExt
+        + OpReceiptBuilder<
             Receipt: DepositReceipt,
-            Transaction: SignedTransaction + op_alloy_consensus::OpTransaction,
+            Transaction: SignedTransaction
+                             + alloy_consensus::Transaction
+                             + op_alloy_consensus::OpTransaction,
         > + Clone
         + Send
         + Sync
         + Unpin
         + 'static,
-    F: PostExecEvmFactoryHooks<
-            Tx: FromRecoveredTx<R::Transaction>
-                    + FromTxWithEncoded<R::Transaction>
-                    + TransactionEnv
-                    + OpTxEnv,
-            Precompiles = PrecompilesMap,
-            Spec = OpSpecId,
-            BlockEnv = BlockEnv,
-        > + Debug
-        + Clone
-        + Send
-        + Sync
-        + Unpin
-        + 'static,
+    celo_revm::CeloTransaction<revm::context::TxEnv>:
+        FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Self: Send + Sync + Unpin + Clone + 'static,
 {
     fn post_exec_executor_for_block<'a, DB: Database>(
@@ -365,13 +334,10 @@ where
     > {
         let evm = self.evm_for_block(db, block.header())?;
         let ctx = self.context_for_block_with_post_exec_mode(block, Some(post_exec_mode));
+        // Bind a fresh receipt builder to this EVM's per-instance CIP-64 storage.
+        let builder = R::with_cip64_storage(evm.cip64_storage().clone());
 
-        Ok(OpBlockExecutor::new(
-            evm,
-            ctx,
-            self.executor_factory.spec(),
-            self.executor_factory.receipt_builder(),
-        ))
+        Ok(OpBlockExecutor::new(evm, ctx, self.executor_factory.spec(), builder))
     }
 
     fn post_exec_builder_for_next_block<'a, DB: Database + 'a>(
@@ -388,20 +354,10 @@ where
         let evm = self.evm_with_env(db, evm_env);
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);
-        let executor = OpBlockExecutor::new(
-            evm,
-            ctx.clone(),
-            self.executor_factory.spec(),
-            self.executor_factory.receipt_builder(),
-        );
+        let builder = R::with_cip64_storage(evm.cip64_storage().clone());
+        let executor = OpBlockExecutor::new(evm, ctx.clone(), self.executor_factory.spec(), builder);
 
-        Ok(BasicBlockBuilder::<
-            'a,
-            OpBlockExecutorFactory<R, Arc<ChainSpec>, PostExecEvmFactoryAdapter<F>>,
-            _,
-            _,
-            N,
-        > {
+        Ok(BasicBlockBuilder::<'a, CeloBlockExecutorFactory<R, Arc<ChainSpec>>, _, _, N> {
             executor,
             transactions: alloc::vec::Vec::new(),
             ctx,
@@ -412,7 +368,7 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<ChainSpec, N, R, EvmF> ConfigureEngineEvm<OpExecData> for CeloEvmConfig<ChainSpec, N, R, EvmF>
+impl<ChainSpec, N, R> ConfigureEngineEvm<OpExecData> for CeloEvmConfig<ChainSpec, N, R>
 where
     ChainSpec: EthChainSpec<Header = Header> + OpHardforks,
     N: NodePrimitives<
@@ -422,28 +378,24 @@ where
             BlockBody = alloy_consensus::BlockBody<R::Transaction>,
             Block = alloy_consensus::Block<R::Transaction>,
         >,
-    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
-    EvmF: EvmFactory<
-            Tx: FromRecoveredTx<R::Transaction>
-                    + FromTxWithEncoded<R::Transaction>
-                    + TransactionEnv
-                    + OpTxEnv,
-            Spec = OpSpecId,
-            BlockEnv = BlockEnv,
-            Precompiles = PrecompilesMap,
-        > + Debug,
-    OpBlockExecutorFactory<R, Arc<ChainSpec>, EvmF>: for<'a> BlockExecutorFactory<
-            EvmFactory = EvmF,
-            ExecutionCtx<'a> = OpBlockExecutionCtx,
-            Transaction = R::Transaction,
-            Receipt = R::Receipt,
-        >,
+    R: alloy_celo_evm::block::CeloReceiptBuilderExt
+        + OpReceiptBuilder<
+            Receipt: DepositReceipt,
+            Transaction: SignedTransaction
+                             + alloy_consensus::Transaction
+                             + op_alloy_consensus::OpTransaction,
+        > + Send
+        + Sync
+        + 'static,
+    celo_revm::CeloTransaction<revm::context::TxEnv>:
+        FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     Self: Send + Sync + Unpin + Clone + 'static,
 {
     fn evm_env_for_payload(&self, payload: &OpExecData) -> Result<EvmEnvFor<Self>, Self::Error> {
         use alloy_primitives::U256;
         use revm::{
-            context::CfgEnv, context_interface::block::BlobExcessGasAndPrice,
+            context::{BlockEnv, CfgEnv},
+            context_interface::block::BlobExcessGasAndPrice,
             primitives::hardfork::SpecId,
         };
 

--- a/crates/celo-reth/src/receipts.rs
+++ b/crates/celo-reth/src/receipts.rs
@@ -51,6 +51,10 @@ impl OpReceiptBuilder for CeloRethReceiptBuilder {
 
                 // Get CIP-64 receipt data from storage (stored during handler execution)
                 let receipt_data = self.cip64_storage.pop_cip64_receipt_data();
+                assert!(
+                    receipt_data.is_some() || !success,
+                    "CIP-64 tx succeeded but no receipt data was stored — transact_raw invariant violated"
+                );
 
                 if let Some(data) = &receipt_data {
                     logs = Cip64Storage::merge_logs(&data.cip64_info, logs);

--- a/crates/celo-reth/src/receipts.rs
+++ b/crates/celo-reth/src/receipts.rs
@@ -20,7 +20,7 @@ use reth_evm::Evm;
 #[non_exhaustive]
 pub struct CeloRethReceiptBuilder {
     /// Storage for CIP-64 transaction execution results, scoped to one block executor.
-    pub cip64_storage: Cip64Storage,
+    pub(crate) cip64_storage: Cip64Storage,
 }
 
 impl CeloRethReceiptBuilder {

--- a/crates/celo-reth/src/receipts.rs
+++ b/crates/celo-reth/src/receipts.rs
@@ -1,7 +1,7 @@
 //! Celo receipt builder for reth, producing bloomless [`CeloReceipt`] types.
 
 use crate::{primitives::CeloTransactionSigned, receipt::CeloReceipt};
-use alloy_celo_evm::cip64_storage::Cip64Storage;
+use alloy_celo_evm::{block::CeloReceiptBuilderExt, cip64_storage::Cip64Storage};
 use alloy_consensus::Eip658Value;
 use alloy_evm::eth::receipt_builder::ReceiptBuilderCtx;
 use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
@@ -12,11 +12,14 @@ use reth_evm::Evm;
 /// Receipt builder that produces bloomless [`CeloReceipt`] types for reth storage.
 ///
 /// Analogous to [`OpRethReceiptBuilder`](reth_optimism_evm::OpRethReceiptBuilder) but with
-/// CIP-64 fee currency support.
+/// CIP-64 fee currency support. The [`Cip64Storage`] handle is bound to one block executor:
+/// [`CeloBlockExecutorFactory`](alloy_celo_evm::block::CeloBlockExecutorFactory) constructs a
+/// fresh builder per block from the executing EVM's own storage, so two consumers running
+/// through the same factory never share pending CIP-64 receipt data.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct CeloRethReceiptBuilder {
-    /// Storage for CIP-64 transaction execution results.
+    /// Storage for CIP-64 transaction execution results, scoped to one block executor.
     pub cip64_storage: Cip64Storage,
 }
 
@@ -24,6 +27,12 @@ impl CeloRethReceiptBuilder {
     /// Creates a new receipt builder with the given CIP-64 storage.
     pub const fn new(cip64_storage: Cip64Storage) -> Self {
         Self { cip64_storage }
+    }
+}
+
+impl CeloReceiptBuilderExt for CeloRethReceiptBuilder {
+    fn with_cip64_storage(storage: Cip64Storage) -> Self {
+        Self::new(storage)
     }
 }
 

--- a/crates/celo-reth/src/receipts.rs
+++ b/crates/celo-reth/src/receipts.rs
@@ -1,7 +1,7 @@
 //! Celo receipt builder for reth, producing bloomless [`CeloReceipt`] types.
 
 use crate::{primitives::CeloTransactionSigned, receipt::CeloReceipt};
-use alloy_celo_evm::{block::CeloReceiptBuilderExt, cip64_storage::Cip64Storage};
+use alloy_celo_evm::cip64_storage::Cip64Storage;
 use alloy_consensus::Eip658Value;
 use alloy_evm::eth::receipt_builder::ReceiptBuilderCtx;
 use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
@@ -30,9 +30,9 @@ impl CeloRethReceiptBuilder {
     }
 }
 
-impl CeloReceiptBuilderExt for CeloRethReceiptBuilder {
-    fn with_cip64_storage(storage: Cip64Storage) -> Self {
-        Self::new(storage)
+impl From<Cip64Storage> for CeloRethReceiptBuilder {
+    fn from(cip64_storage: Cip64Storage) -> Self {
+        Self::new(cip64_storage)
     }
 }
 

--- a/crates/kona/executor/src/builder/core.rs
+++ b/crates/kona/executor/src/builder/core.rs
@@ -2,15 +2,17 @@
 //! execution.
 
 use alloc::{string::ToString, vec::Vec};
-use alloy_celo_evm::{CeloEvmFactory, block::CeloAlloyReceiptBuilder, cip64_storage::Cip64Storage};
+use alloy_celo_evm::{
+    CeloEvmFactory,
+    block::{CeloAlloyReceiptBuilder, CeloBlockExecutorFactory},
+    cip64_storage::Cip64Storage,
+};
 use alloy_consensus::{Header, Sealed, crypto::RecoveryError};
 use alloy_evm::{
     EvmFactory, RecoveredTx,
     block::{BlockExecutionResult, BlockExecutor, BlockExecutorFactory},
 };
-use alloy_op_evm::{
-    OpBlockExecutionCtx, OpBlockExecutorFactory, PostExecMode, post_exec::PostExecEvmFactoryAdapter,
-};
+use alloy_op_evm::{OpBlockExecutionCtx, PostExecMode};
 use celo_alloy_consensus::CeloReceiptEnvelope;
 use celo_alloy_rpc_types_engine::CeloPayloadAttributes;
 use celo_genesis::CeloRollupConfig;
@@ -34,12 +36,9 @@ where
     pub(crate) trie_db: TrieDB<P, H>,
     #[allow(rustdoc::broken_intra_doc_links)]
     /// The executor factory, used to create new [`celo_revm::CeloEvm`] instances for block
-    /// building routines.
-    pub(crate) factory: OpBlockExecutorFactory<
-        CeloAlloyReceiptBuilder,
-        CeloRollupConfig,
-        PostExecEvmFactoryAdapter<CeloEvmFactory>,
-    >,
+    /// building routines. Each `create_executor` call constructs a fresh
+    /// [`CeloAlloyReceiptBuilder`] bound to that EVM's own [`Cip64Storage`].
+    pub(crate) factory: CeloBlockExecutorFactory<CeloAlloyReceiptBuilder, CeloRollupConfig>,
 }
 
 impl<'a, P, H> CeloStatelessL2Builder<'a, P, H>
@@ -56,11 +55,7 @@ where
         parent_header: Sealed<Header>,
     ) -> Self {
         let trie_db = TrieDB::new(parent_header, provider, hinter);
-        let factory = OpBlockExecutorFactory::new(
-            CeloAlloyReceiptBuilder::default(),
-            config.clone(),
-            PostExecEvmFactoryAdapter::new(evm_factory),
-        );
+        let factory = CeloBlockExecutorFactory::new(config.clone(), evm_factory);
         Self { config, trie_db, factory }
     }
 
@@ -110,19 +105,11 @@ where
             State::builder().with_database(&mut self.trie_db).with_bundle_update().build();
         let evm = self.factory.evm_factory().create_evm(&mut state, evm_env);
 
-        // Update the receipt builder with the shared CIP-64 storage from the EVM so that
-        // receipt data written during execution can be read when building receipts.
+        // Grab the EVM's own CIP-64 storage before handing the EVM to the executor — the
+        // factory binds a fresh receipt builder to it inside `create_executor`, and we
+        // also need a handle to return in `CeloBlockBuildingOutcome` so callers (e.g.
+        // CIP-64 gas-accounting tests) can read post-execution entries.
         let cip64_storage = evm.cip64_storage().clone();
-        let updated_receipt_builder = CeloAlloyReceiptBuilder::new(cip64_storage.clone());
-        let factory = OpBlockExecutorFactory::<
-            CeloAlloyReceiptBuilder,
-            CeloRollupConfig,
-            PostExecEvmFactoryAdapter<CeloEvmFactory>,
-        >::new(
-            updated_receipt_builder,
-            self.config.clone(),
-            self.factory.evm_factory().clone(),
-        );
 
         // Step 3. Decode and validate the block transactions within the payload attributes.
         let transactions = attrs
@@ -146,7 +133,7 @@ where
             extra_data: Default::default(),
             post_exec_mode,
         };
-        let executor = factory.create_executor(evm, ctx);
+        let executor = self.factory.create_executor(evm, ctx);
 
         let ex_result = executor.execute_block(transactions.iter())?;
 


### PR DESCRIPTION
This PR is meant to cleanly address the problem worked around in https://github.com/celo-org/celo-kona/pull/175/changes/03982031ee9e9256d5e356b10133700a1457bee2 (part of #175), since I don't want to merge that work-around.

Moves `Cip64Storage` from the factory to each `CeloEvm` instance so two executors sharing a factory can't collide on pending CIP-64 receipt data. Introduces `CeloBlockExecutorFactory<R, Spec>`, which binds each executor's receipt builder to that EVM's own storage in `create_executor`, dropping the now-unnecessary `PostExecEvmFactoryAdapter` wrapper.

Also addresses three findings from a post-review of #175: a silent receipt corruption on CIP-64 storage under-pop (now an `assert!`), externally-mutable `cip64_storage` fields narrowed to `pub(crate)`, and the `PostExecEvm` no-op methods changed to `panic!` so an accidental SDM activation surfaces immediately.