### PR TITLE
refactor: share CIP-64 receipt construction across alloy & reth builders

### DIFF
--- a/crates/alloy-celo-evm/src/block/receipt_builder.rs
+++ b/crates/alloy-celo-evm/src/block/receipt_builder.rs
@@ -4,7 +4,7 @@
 use alloy_consensus::Eip658Value;
 use alloy_evm::{Evm, eth::receipt_builder::ReceiptBuilderCtx};
 use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
-use celo_alloy_consensus::{CeloCip64Receipt, CeloReceiptEnvelope, CeloTxEnvelope, CeloTxType};
+use celo_alloy_consensus::{CeloReceiptEnvelope, CeloTxEnvelope, CeloTxType};
 use core::fmt::Debug;
 use op_alloy_consensus::OpDepositReceipt;
 
@@ -46,31 +46,7 @@ impl OpReceiptBuilder for CeloAlloyReceiptBuilder {
     ) -> Result<Self::Receipt, ReceiptBuilderCtx<'a, CeloTxType, E>> {
         match ctx.tx_type {
             CeloTxType::Cip64 => {
-                let success = ctx.result.is_success();
-                let mut logs = ctx.result.into_logs();
-
-                // Pop the CIP-64 receipt data stored during transact_raw
-                let cip64_data = self.cip64_storage.pop_cip64_receipt_data();
-                assert!(
-                    cip64_data.is_some() || !success,
-                    "CIP-64 tx succeeded but no receipt data was stored — transact_raw invariant violated"
-                );
-                let base_fee_in_erc20 =
-                    cip64_data.as_ref().and_then(|d| d.cip64_info.base_fee_in_erc20);
-
-                // Merge CIP-64 pre/post logs if available
-                if let Some(data) = &cip64_data {
-                    logs = Cip64Storage::merge_logs(&data.cip64_info, logs);
-                }
-
-                let receipt = CeloCip64Receipt {
-                    inner: alloy_consensus::Receipt {
-                        status: Eip658Value::Eip658(success),
-                        cumulative_gas_used: ctx.cumulative_gas_used,
-                        logs,
-                    },
-                    base_fee: base_fee_in_erc20,
-                };
+                let receipt = self.cip64_storage.build_cip64_receipt(ctx);
                 Ok(CeloReceiptEnvelope::Cip64(receipt.with_bloom()))
             }
             CeloTxType::Deposit => Err(ctx),

--- a/crates/alloy-celo-evm/src/cip64_storage.rs
+++ b/crates/alloy-celo-evm/src/cip64_storage.rs
@@ -4,9 +4,11 @@
 //! execution results between the EVM handler and the receipt builder.
 
 use alloc::{sync::Arc, vec::Vec};
+use alloy_consensus::Eip658Value;
+use alloy_evm::{Evm, eth::receipt_builder::ReceiptBuilderCtx};
 use alloy_primitives::Address;
+use celo_alloy_consensus::{CeloCip64Receipt, CeloTxType};
 use celo_revm::Cip64Info;
-use revm::primitives::Log;
 use spin::Mutex;
 
 /// Data needed by the receipt builder for a CIP-64 transaction.
@@ -80,14 +82,48 @@ impl Cip64Storage {
         self.all_entries.lock().clone()
     }
 
-    /// Merges CIP-64 pre/post logs with the main execution logs.
-    pub fn merge_logs(cip64_info: &Cip64Info, main_logs: Vec<Log>) -> Vec<Log> {
-        let capacity = cip64_info.logs_pre.len() + main_logs.len() + cip64_info.logs_post.len();
-        let mut merged = Vec::with_capacity(capacity);
-        merged.extend_from_slice(&cip64_info.logs_pre);
-        merged.extend(main_logs);
-        merged.extend_from_slice(&cip64_info.logs_post);
-        merged
+    /// Builds the inner [`CeloCip64Receipt`] for a CIP-64 transaction, popping the pending
+    /// entry and merging its pre/post logs into the main execution logs.
+    ///
+    /// Callers wrap the result in their receipt envelope variant — bloomed for canonical
+    /// types ([`CeloReceiptEnvelope`](celo_alloy_consensus::CeloReceiptEnvelope)) or
+    /// bloomless for reth's on-disk format (`CeloReceipt`).
+    pub fn build_cip64_receipt<E: Evm>(
+        &self,
+        ctx: ReceiptBuilderCtx<'_, CeloTxType, E>,
+    ) -> CeloCip64Receipt {
+        let success = ctx.result.is_success();
+        let main_logs = ctx.result.into_logs();
+
+        // Pop the CIP-64 receipt data stored during transact_raw
+        let cip64_data = self.pop_cip64_receipt_data();
+        assert!(
+            cip64_data.is_some() || !success,
+            "CIP-64 tx succeeded but no receipt data was stored — transact_raw invariant violated"
+        );
+
+        // Merge CIP-64 pre/post logs with the main execution logs if available
+        let logs = if let Some(data) = &cip64_data {
+            let info = &data.cip64_info;
+            let capacity = info.logs_pre.len() + main_logs.len() + info.logs_post.len();
+            let mut merged = Vec::with_capacity(capacity);
+            merged.extend_from_slice(&info.logs_pre);
+            merged.extend(main_logs);
+            merged.extend_from_slice(&info.logs_post);
+            merged
+        } else {
+            main_logs
+        };
+
+        let base_fee_in_erc20 = cip64_data.as_ref().and_then(|d| d.cip64_info.base_fee_in_erc20);
+        CeloCip64Receipt {
+            inner: alloy_consensus::Receipt {
+                status: Eip658Value::Eip658(success),
+                cumulative_gas_used: ctx.cumulative_gas_used,
+                logs,
+            },
+            base_fee: base_fee_in_erc20,
+        }
     }
 }
 

--- a/crates/celo-reth/src/receipts.rs
+++ b/crates/celo-reth/src/receipts.rs
@@ -5,7 +5,7 @@ use alloy_celo_evm::cip64_storage::Cip64Storage;
 use alloy_consensus::Eip658Value;
 use alloy_evm::eth::receipt_builder::ReceiptBuilderCtx;
 use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
-use celo_alloy_consensus::{CeloCip64Receipt, CeloTxType};
+use celo_alloy_consensus::CeloTxType;
 use op_alloy_consensus::OpDepositReceipt;
 use reth_evm::Evm;
 
@@ -46,31 +46,7 @@ impl OpReceiptBuilder for CeloRethReceiptBuilder {
     ) -> Result<Self::Receipt, ReceiptBuilderCtx<'a, CeloTxType, E>> {
         match ctx.tx_type {
             CeloTxType::Cip64 => {
-                let success = ctx.result.is_success();
-                let mut logs = ctx.result.into_logs();
-
-                // Get CIP-64 receipt data from storage (stored during handler execution)
-                let receipt_data = self.cip64_storage.pop_cip64_receipt_data();
-                assert!(
-                    receipt_data.is_some() || !success,
-                    "CIP-64 tx succeeded but no receipt data was stored — transact_raw invariant violated"
-                );
-
-                if let Some(data) = &receipt_data {
-                    logs = Cip64Storage::merge_logs(&data.cip64_info, logs);
-                }
-
-                let base_fee_in_erc20 =
-                    receipt_data.as_ref().and_then(|d| d.cip64_info.base_fee_in_erc20);
-
-                Ok(CeloReceipt::Cip64(CeloCip64Receipt {
-                    inner: alloy_consensus::Receipt {
-                        status: Eip658Value::Eip658(success),
-                        cumulative_gas_used: ctx.cumulative_gas_used,
-                        logs,
-                    },
-                    base_fee: base_fee_in_erc20,
-                }))
+                Ok(CeloReceipt::Cip64(self.cip64_storage.build_cip64_receipt(ctx)))
             }
             CeloTxType::Deposit => Err(ctx),
             ty => {


### PR DESCRIPTION
## Summary
- Move duplicated CIP-64 receipt-building logic onto `Cip64Storage::build_cip64_receipt`.
- `CeloAlloyReceiptBuilder` and `CeloRethReceiptBuilder` each shrink to a one-liner wrapping the returned `CeloCip64Receipt` in their envelope variant — bloomed `CeloReceiptEnvelope::Cip64` (canonical) vs. bloomless `CeloReceipt::Cip64` (reth on-disk).
- Inline the now single-caller `merge_logs` helper.

The two builders still exist (the `OpReceiptBuilder` trait's `Transaction`/`Receipt` associated types differ across them), but the only remaining divergence is the wrapping variant + `.with_bloom()` call.