### PR TITLE
feat(celo-reth): add download and snapshot-manifest subcommands

### DIFF
--- a/crates/celo-reth/src/bin/celo_reth.rs
+++ b/crates/celo-reth/src/bin/celo_reth.rs
@@ -12,10 +12,14 @@ use celo_reth::{
     },
     state_import::ImportCeloStateCommand,
 };
-use clap::{CommandFactory, Parser};
+use clap::{CommandFactory, FromArgMatches, Parser};
 use futures_util::FutureExt;
 use reth_chainspec::EthChainSpec;
-use reth_cli_commands::{db, p2p, prune, re_execute, stage};
+use reth_cli_commands::{
+    db,
+    download::{DownloadCommand, manifest_cmd::SnapshotManifestCommand},
+    p2p, prune, re_execute, stage,
+};
 use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_db_api::database_metrics::DatabaseMetrics;
@@ -43,16 +47,37 @@ const DB: &str = "db";
 const P2P: &str = "p2p";
 const PRUNE: &str = "prune";
 const RE_EXECUTE: &str = "re-execute";
+const DOWNLOAD: &str = "download";
+const SNAPSHOT_MANIFEST: &str = "snapshot-manifest";
 
 /// All Celo-intercepted subcommand names. Each one is dispatched in `run_celo_subcommand`
 /// against `CeloNode` instead of letting op-reth's `Cli` route it to `OpNode`.
-const CELO_SUBCOMMANDS: &[&str] = &[IMPORT_CELO_STATE, STAGE, DB, P2P, PRUNE, RE_EXECUTE];
+const CELO_SUBCOMMANDS: &[&str] = &[
+    IMPORT_CELO_STATE,
+    STAGE,
+    DB,
+    P2P,
+    PRUNE,
+    RE_EXECUTE,
+    DOWNLOAD,
+    SNAPSHOT_MANIFEST,
+];
 
 // TODO: `proofs unwind` is intentionally NOT intercepted: its upstream `execute<N>` binds
 // `N::Primitives = OpPrimitives`, which `CeloNode` can't satisfy. It will panic on the
 // first CIP-64 transaction it touches. See https://github.com/celo-org/celo-kona/issues/189
 // for the port plan. `proofs init` and `proofs prune` are safe on the op-reth dispatch
 // (no tx decoding).
+
+/// Default snapshot manifest URL for `celo-reth download`. Overrides the upstream
+/// `--manifest-url` default (which is empty, triggering interactive selection against
+/// `snapshots.reth.rs` — an Ethereum-mainnet-only host).
+const DEFAULT_MANIFEST_URL: &str =
+    "https://fsn1.your-objectstorage.com/celo/snapshots/manifest.json";
+
+/// Default chain ID embedded in `celo-reth snapshot-manifest` output. Overrides the upstream
+/// `--chain-id` default of `1` (Ethereum mainnet).
+const DEFAULT_CHAIN_ID: &str = "42220";
 
 /// Top-level Celo-only subcommand wrapper.
 ///
@@ -91,6 +116,14 @@ enum CeloCommand {
     /// Re-execute blocks in parallel to verify historical sync correctness.
     #[command(name = RE_EXECUTE)]
     ReExecute(re_execute::Command<CeloChainSpecParser>),
+    /// Download a Celo reth snapshot. Defaults `--manifest-url` to the cLabs-operated
+    /// publication endpoint; pass `--url`, `--manifest-url`, or `--manifest-path` to override.
+    #[command(name = DOWNLOAD)]
+    Download(Box<DownloadCommand<CeloChainSpecParser>>),
+    /// Generate a chunked snapshot manifest from a local datadir (publisher tool).
+    /// Defaults `--chain-id` to Celo Mainnet (42220).
+    #[command(name = SNAPSHOT_MANIFEST)]
+    SnapshotManifest(Box<SnapshotManifestCommand>),
 }
 
 impl CeloCommand {
@@ -102,8 +135,22 @@ impl CeloCommand {
             Self::P2P(command) => command.chain_spec(),
             Self::Prune(command) => command.chain_spec(),
             Self::ReExecute(command) => command.chain_spec(),
+            Self::Download(command) => command.chain_spec(),
+            Self::SnapshotManifest(_) => None,
         }
     }
+}
+
+/// Build the Celo clap [`Command`] with Celo-specific argument defaults applied. The defaults
+/// override upstream values that are Ethereum-mainnet-centric (chain id 1, snapshots.reth.rs).
+fn celo_cli_command() -> clap::Command {
+    CeloCli::command()
+        .mut_subcommand(SNAPSHOT_MANIFEST, |sub| {
+            sub.mut_arg("chain_id", |a| a.default_value(DEFAULT_CHAIN_ID))
+        })
+        .mut_subcommand(DOWNLOAD, |sub| {
+            sub.mut_arg("manifest_url", |a| a.default_value(DEFAULT_MANIFEST_URL))
+        })
 }
 
 #[global_allocator]
@@ -153,7 +200,10 @@ fn main() {
     // the subcommand slot (where we surface clap's own help/version/error output instead of a
     // confusing "unrecognized subcommand" from op-reth).
     let argv: Vec<OsString> = std::env::args_os().collect();
-    match CeloCli::try_parse_from(&argv) {
+    let parsed = celo_cli_command()
+        .try_get_matches_from(&argv)
+        .and_then(|m| CeloCli::from_arg_matches(&m));
+    match parsed {
         Ok(cli) => {
             if let Err(err) = run_celo_subcommand(cli) {
                 eprintln!("Error: {err:?}");
@@ -323,6 +373,12 @@ fn run_celo_subcommand(mut cli: CeloCli) -> eyre::Result<()> {
             let runtime = runner.runtime();
             runner.run_until_ctrl_c(cmd.execute::<CeloNode>(components, runtime))
         }
+        // Download is chain-agnostic file shuttling; CeloNode satisfies the `N` type bound
+        // without requiring Celo-aware decoding (archives are tarballs over MDBX + static files).
+        CeloCommand::Download(cmd) => runner.run_until_ctrl_c(cmd.execute::<CeloNode>()),
+        // Snapshot manifest generation is synchronous: it tars static files and reads the
+        // `Finish` stage checkpoint from MDBX read-only. No runtime needed.
+        CeloCommand::SnapshotManifest(cmd) => cmd.execute(),
     }
 }
 

--- a/crates/celo-reth/src/bin/celo_reth.rs
+++ b/crates/celo-reth/src/bin/celo_reth.rs
@@ -52,16 +52,8 @@ const SNAPSHOT_MANIFEST: &str = "snapshot-manifest";
 
 /// All Celo-intercepted subcommand names. Each one is dispatched in `run_celo_subcommand`
 /// against `CeloNode` instead of letting op-reth's `Cli` route it to `OpNode`.
-const CELO_SUBCOMMANDS: &[&str] = &[
-    IMPORT_CELO_STATE,
-    STAGE,
-    DB,
-    P2P,
-    PRUNE,
-    RE_EXECUTE,
-    DOWNLOAD,
-    SNAPSHOT_MANIFEST,
-];
+const CELO_SUBCOMMANDS: &[&str] =
+    &[IMPORT_CELO_STATE, STAGE, DB, P2P, PRUNE, RE_EXECUTE, DOWNLOAD, SNAPSHOT_MANIFEST];
 
 // TODO: `proofs unwind` is intentionally NOT intercepted: its upstream `execute<N>` binds
 // `N::Primitives = OpPrimitives`, which `CeloNode` can't satisfy. It will panic on the
@@ -200,9 +192,8 @@ fn main() {
     // the subcommand slot (where we surface clap's own help/version/error output instead of a
     // confusing "unrecognized subcommand" from op-reth).
     let argv: Vec<OsString> = std::env::args_os().collect();
-    let parsed = celo_cli_command()
-        .try_get_matches_from(&argv)
-        .and_then(|m| CeloCli::from_arg_matches(&m));
+    let parsed =
+        celo_cli_command().try_get_matches_from(&argv).and_then(|m| CeloCli::from_arg_matches(&m));
     match parsed {
         Ok(cli) => {
             if let Err(err) = run_celo_subcommand(cli) {


### PR DESCRIPTION
## Summary

Extends the existing `CeloCommand` argv-intercept to expose upstream reth's `download` and `snapshot-manifest` subcommands, with Celo-specific argument defaults applied via clap mutation.

- `celo-reth download` — fetch a published snapshot manifest and rebuild a datadir from chunked archives. Default `--manifest-url` set to the cLabs publication endpoint.
- `celo-reth snapshot-manifest` — chunk a local datadir into per-component archives + write `manifest.json`. Default `--chain-id` set to `42220` (Celo Mainnet).

## Motivation

Today, bootstrapping a celo-reth archive node from scratch requires either replaying every block from genesis (very slow for archive) or using ad-hoc snapshot distribution (one-off tarballs, no chunking, no resume). Upstream reth has a native snapshot pipeline (manifest + chunked component archives) but the surface wasn't reachable from `op-reth`'s `Commands` enum, so celo-reth inherited the gap.

## Validation

Before submitting, ran upstream `reth 2.2.0` `snapshot-manifest` directly against a 743 GB celo-mainnet archive datadir (block 67,728,745, taken via ZFS snapshot of a live op-reth instance). All 8 component types produced chunks successfully with no errors:

| Component | Chunks | Compressed |
|---|---:|---:|
| `headers` | 136 | 10.9 GiB |
| `transactions` | 136 | 79.6 GiB |
| `transaction_senders` | 136 | 6.7 GiB |
| `receipts` | 136 | 50.4 GiB |
| `account_changesets` | 136 | 12.9 GiB |
| `storage_changesets` | 136 | 83.9 GiB |
| `state` (mdbx) | 1 | 72.3 GiB |
| `rocksdb_indices` | 1 | 37.4 GiB |
| **Total** | **818** | **354 GiB** |

`storage_version: 2` was correctly stamped, `chain_id: 42220` was propagated. Chunk-count math: `67,728,745 / 500,000 = 136` per chunked segment, matching exactly. No celo-specific code needed in upstream for any of this to work — the commands operate on file shapes, not chain semantics.

## Implementation notes

**Pattern**: extends the existing argv-intercept (\`CeloCommand\` enum + \`celo_cli_command()\` factory) the same way #181 added \`stage\`. No new vendoring; \`DownloadCommand\` and \`SnapshotManifestCommand\` are imported directly from \`reth-cli-commands\` (already a dep, already at the right rev \`88505c7\`).

**Defaults via clap mutation**: rather than wrapping the upstream types in Celo-specific structs (which would duplicate every field), defaults are applied at runtime via \`Command::mut_subcommand(name).mut_arg(id, |a| a.default_value(...))\`. This keeps the diff small and means upstream bumps don't require re-wrapping.

**Trade-off — top-level \`--help\` visibility**: the new commands are reachable as \`celo-reth download\` / \`celo-reth snapshot-manifest\` with full per-command \`--help\`, but they don't appear in the top-level \`celo-reth --help\` listing (which falls through to op-reth's \`Cli\`). This is consistent with the existing \`import-celo-state\` / \`stage\` / etc. intercepted commands. Lifting it would require mirroring op-reth's full 14-variant \`Commands\` enum in this crate — happy to do that as a follow-up PR if maintainers prefer.

**\`DEFAULT_MANIFEST_URL\` is a dev/test URL** (cLabs Hetzner Object Storage in fsn1). The intent is to replace with a canonical \`celo.org\`-hosted endpoint once the snapshot distribution service goes live; updating that constant is a one-liner.

## Test plan

- [x] \`cargo check -p celo-reth --bin celo-reth\` — passes
- [x] \`cargo build -p celo-reth --bin celo-reth\` — passes  
- [x] \`celo-reth download --help\` shows \`[default: https://fsn1.your-objectstorage.com/celo/snapshots/manifest.json]\` for \`--manifest-url\`
- [x] \`celo-reth snapshot-manifest --help\` shows \`[default: 42220]\` for \`--chain-id\`
- [x] \`celo-reth --help\` still works (falls through to op-reth's Cli, shows 14 op-reth commands)
- [x] \`celo-reth download --bogus-flag\` surfaces Celo-side clap error (not op-reth fallthrough)
- [x] \`celo-reth foo-bar\` surfaces op-reth's "unrecognized subcommand" (correct fallthrough)
- [ ] End-to-end: produce a manifest with \`celo-reth snapshot-manifest\`, then download it on a separate host with \`celo-reth download\`, then launch \`celo-reth node\` against the recovered datadir. **(Pending a hosted manifest.json — current uploads only have the monolithic tarball, not the chunked variant. Will follow up once cLabs publishes one.)**