### PR TITLE
Confine fee-currency blocklist to the sequencing path

### DIFF
--- a/crates/alloy-celo-evm/src/blocklist.rs
+++ b/crates/alloy-celo-evm/src/blocklist.rs
@@ -1,13 +1,16 @@
 //! Fee currency blocklist for CIP-64 transactions.
 //!
 //! Provides a thread-safe blocklist mechanism for fee currencies that cause execution
-//! errors. When a fee currency is blocklisted, CIP-64 transactions using that currency
-//! are rejected early during block building, avoiding repeated execution failures.
+//! errors. When a CIP-64 fee-currency debit/credit fails during execution, the currency
+//! is added here; the sequencing-time payload filter then skips transactions using that
+//! currency, avoiding repeated execution failures.
 //!
-//! This lives in `alloy-celo-evm` (not `celo-reth`) because it is checked inside
-//! `CeloEvm::transact_raw()` — the shared execution path used by both reth and any other
-//! consumer of `CeloEvmFactory`. Kona/ZK paths do not need it and use the default empty
-//! blocklist on `CeloEvmFactory::default()`.
+//! This is a *local sequencing heuristic*. It is populated inside `CeloEvm::transact_raw()`,
+//! but only for EVMs built on the sequencing path (`blocklist_enabled`); block import and
+//! derivation re-execution leave it untouched, so a node's locally-accumulated blocklist can
+//! never affect whether it accepts a canonical block. Rejection itself is also sequencing-only,
+//! enforced by `CeloFeeCurrencyFilter` in `celo-reth`'s `payload.rs`. Kona/ZK paths do not need
+//! it and use the default empty blocklist on `CeloEvmFactory::default()`.
 //!
 //! Blocklisting can be controlled per-currency via admin RPCs:
 //! - `admin_disableBlocklistFeeCurrencies`: Prevents a currency from being blocklisted.
@@ -35,9 +38,10 @@ struct BlocklistState {
 
 /// Shared, thread-safe fee currency blocklist.
 ///
-/// When a CIP-64 transaction using a particular fee currency fails during EVM
-/// execution, the currency is added to the blocklist. Subsequent transactions
-/// using that currency are rejected early without EVM execution.
+/// When a CIP-64 transaction using a particular fee currency fails its fee-currency
+/// debit/credit during EVM execution on the sequencing path, the currency is added to the
+/// blocklist. The sequencing-time payload filter (`CeloFeeCurrencyFilter`) then skips
+/// subsequent transactions using that currency before they reach the executor.
 #[derive(Debug, Clone, Default)]
 pub struct FeeCurrencyBlocklist {
     inner: Arc<Mutex<BlocklistState>>,

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -162,6 +162,19 @@ pub struct CeloEvm<DB: Database, I, P = CeloPrecompiles> {
     inspect: bool,
     cip64_storage: Cip64Storage,
     blocklist: FeeCurrencyBlocklist,
+    /// Whether this EVM reads from and writes to the fee currency [`blocklist`](Self::blocklist).
+    ///
+    /// The blocklist is a *local sequencing heuristic*: it records currencies whose debit/credit
+    /// calls failed while the node was building a block from its own mempool, so the sequencer
+    /// can skip them for a while. It must therefore only be touched on the sequencing path.
+    /// Block import and derivation re-execute already-canonical blocks and must produce identical
+    /// results regardless of this node's accumulated heuristic, so they leave it alone entirely.
+    ///
+    /// EVMs are created with this `false` by default ([`CeloEvmFactory::create_evm`], used by the
+    /// import/derivation executor and RPC). It is flipped to `true` only by
+    /// `CeloEvmConfig::builder_for_next_block` — the one entry point reth routes sequencing
+    /// through (the payload builder), and which import/derivation deliberately bypass.
+    blocklist_enabled: bool,
     /// Block timestamp of the last eviction call, used to avoid redundant eviction
     /// on every `transact_raw` call within the same block.
     last_evicted_timestamp: u64,
@@ -209,8 +222,18 @@ impl<DB: Database, I, P> CeloEvm<DB, I, P> {
             inspect,
             cip64_storage: Cip64Storage::default(),
             blocklist: FeeCurrencyBlocklist::default(),
+            blocklist_enabled: false,
             last_evicted_timestamp: 0,
         }
+    }
+
+    /// Enables fee currency blocklist reads/writes for this EVM. Called only on the sequencing
+    /// path (`CeloEvmConfig::builder_for_next_block`); import, derivation and RPC leave it off so
+    /// they never touch the shared blocklist.
+    #[must_use]
+    pub const fn with_blocklist_enabled(mut self) -> Self {
+        self.blocklist_enabled = true;
+        self
     }
 }
 
@@ -264,13 +287,23 @@ where
         // Capture fee_currency before execution (it's consumed by transact)
         let fee_currency = tx.fee_currency;
 
-        // Only apply blocklist during block building, not during RPC simulation
-        // (eth_call, eth_estimateGas). RPC simulation disables the base fee check.
-        let is_block_building = !self.ctx().cfg.is_base_fee_check_disabled();
+        // The base-fee check is enabled during real state transitions — both sequencing AND block
+        // import / derivation re-execution — and disabled during RPC simulation (`eth_call`,
+        // `eth_estimateGas`, tracing). It gates the CIP-64 receipt-info store, which import and
+        // derivation also need.
+        let base_fee_check_enabled = !self.ctx().cfg.is_base_fee_check_disabled();
+
+        // The fee currency blocklist is a local sequencing heuristic and is only ever touched on
+        // the sequencing path: `blocklist_enabled` is set on EVMs built via
+        // `CeloEvmConfig::builder_for_next_block` (the payload builder) and left off for import /
+        // derivation re-execution and RPC. Import and derivation therefore neither read nor write
+        // it. (The `base_fee_check_enabled` conjunct is redundant given `blocklist_enabled` but
+        // kept as an explicit guard against ever enabling the blocklist on an RPC-simulation EVM.)
+        let apply_blocklist = self.blocklist_enabled && base_fee_check_enabled;
 
         // Evict stale blocklist entries using the current block timestamp,
         // but only once per block to avoid redundant work on every transaction.
-        if is_block_building {
+        if apply_blocklist {
             let block_timestamp: u64 = self.ctx().block.timestamp.to();
             if block_timestamp != self.last_evicted_timestamp {
                 self.blocklist.evict(block_timestamp);
@@ -278,14 +311,13 @@ where
             }
         }
 
-        // NOTE: blocklist *rejection* is intentionally NOT performed here. `is_block_building`
-        // (= base-fee check enabled) is true during both sequencing AND block import /
-        // derivation re-execution, so rejecting here would let a node's locally-accumulated
-        // blocklist reject a valid canonical block built by another sequencer — a cross-node
-        // disagreement on block validity. Rejection is a sequencing-only policy and is enforced
-        // upstream in `CeloFeeCurrencyFilter` (see `celo-reth`'s `payload.rs`), which derivation
-        // deliberately bypasses. Here we only *populate* the blocklist on debit/credit failures
-        // below; that population is harmless during import (valid blocks never fail debit/credit).
+        // NOTE: blocklist *rejection* is intentionally NOT performed here even on the sequencing
+        // path; it is enforced upstream in `CeloFeeCurrencyFilter` (see `celo-reth`'s
+        // `payload.rs`). Performing it here would also catch import/derivation EVMs were
+        // `blocklist_enabled` ever set on them, letting a node's locally-accumulated
+        // blocklist reject a valid canonical block built by another sequencer. Below we
+        // only *populate* the blocklist, and only when `apply_blocklist` holds — so import
+        // and derivation neither read nor write it.
 
         let result = if self.inspect { self.inner.inspect_tx(tx) } else { self.inner.transact(tx) }
             .map_err(map_op_err);
@@ -295,18 +327,19 @@ where
                 // CIP64 NOTE:
                 // Extract and store the cip64 info to a shared storage to be able to add the
                 // credit/debit logs when building the receipt in the receipts_builder.
-                // Only store during block building: storage is per-EVM (so cross-EVM
-                // pollution is impossible), but multi-tx RPC tracing (`debug_traceBlock`,
+                // Only store during real execution (sequencing and import), not RPC
+                // simulation/tracing: storage is per-EVM (so cross-EVM pollution is
+                // impossible), but multi-tx RPC tracing (`debug_traceBlock`,
                 // `debug_traceTransaction`) re-executes multiple txs through one EVM
                 // without calling `build_receipt`. Skipping the store here keeps the
                 // slot-occupied panic in `store_cip64_info` a signal of a real executor
                 // bug instead of firing on legitimate RPC paths.
                 let cip64_info = self.inner.inner.0.ctx.tx.cip64_tx_info.take();
-                if is_block_building && let Some(cip64_info) = cip64_info {
+                if base_fee_check_enabled && let Some(cip64_info) = cip64_info {
                     self.cip64_storage.store_cip64_info(fee_currency, cip64_info);
                 }
             }
-            Err(e) if is_block_building && fee_currency.is_some() => {
+            Err(e) if apply_blocklist && fee_currency.is_some() => {
                 // Only blocklist when the error is a fee-currency debit/credit failure,
                 // not for unrelated validation errors (nonce, gas limit, etc.) that
                 // happen to involve a CIP-64 tx.
@@ -392,8 +425,12 @@ where
 /// slots and never overwrite each other's pending CIP-64 receipt data.
 #[derive(Debug, Default, Clone)]
 pub struct CeloEvmFactory {
-    /// Shared fee currency blocklist. All EVMs created by this factory use this blocklist
-    /// to reject CIP-64 transactions for blocklisted currencies. Defaults to empty.
+    /// Shared fee currency blocklist. EVMs created by this factory *populate* this blocklist
+    /// when a CIP-64 fee-currency debit/credit fails during execution, but only on the sequencing
+    /// path (`CeloEvm::with_blocklist_enabled`); import/derivation EVMs leave it untouched. The
+    /// sequencing-time payload filter (`CeloFeeCurrencyFilter` in `celo-reth`) reads it to skip
+    /// such currencies. `transact_raw` itself never rejects blocklisted currencies. Defaults to
+    /// empty.
     pub blocklist: FeeCurrencyBlocklist,
 }
 
@@ -424,6 +461,10 @@ fn make_test_evm(
         inspect: false,
         cip64_storage: Cip64Storage::default(),
         blocklist,
+        // Tests here exercise the sequencing-path blocklist behaviour, so enable it. The
+        // RPC-simulation test additionally disables the base-fee check, which the
+        // `base_fee_check_enabled` guard in `transact_raw` still honours independently.
+        blocklist_enabled: true,
         last_evicted_timestamp: 0,
     }
 }
@@ -450,6 +491,10 @@ impl CeloEvmFactory {
             inspect,
             cip64_storage: Cip64Storage::default(),
             blocklist: self.blocklist.clone(),
+            // Off by default: the import/derivation executor and RPC create EVMs through the
+            // factory and must not touch the blocklist. Sequencing flips it on via
+            // `with_blocklist_enabled` in `CeloEvmConfig::builder_for_next_block`.
+            blocklist_enabled: false,
             last_evicted_timestamp: 0,
         }
     }
@@ -542,32 +587,40 @@ mod tests {
         }
     }
 
-    /// `transact_raw` must NOT reject a blocklisted currency: `is_block_building`
-    /// (base-fee check enabled) is also true during block import / derivation
-    /// re-execution, so rejecting here would let a node's locally-accumulated
-    /// blocklist reject a valid canonical block. Sequencing-time rejection lives in
-    /// `CeloFeeCurrencyFilter` (see `celo-reth`'s `payload.rs`,
-    /// `filter_skips_blocklisted_currency`), which derivation deliberately bypasses.
+    /// `transact_raw` must NOT reject a blocklisted currency: `base_fee_check_enabled`
+    /// is also true during block import / derivation re-execution, so rejecting here
+    /// would let a node's locally-accumulated blocklist reject a valid canonical block.
+    /// Sequencing-time rejection lives in `CeloFeeCurrencyFilter` (see `celo-reth`'s
+    /// `payload.rs`, `filter_skips_blocklisted_currency`), which derivation deliberately
+    /// bypasses.
     #[test]
     fn test_blocklist_does_not_reject_in_transact_raw() {
         let fc = Address::with_last_byte(0xAA);
-        let blocklist = FeeCurrencyBlocklist::default();
-        blocklist.block_currency(fc, 1000);
 
-        let mut evm = make_test_evm(blocklist);
+        // Run the identical tx through two EVMs — one with `fc` blocklisted, one without —
+        // and assert the outcomes are byte-for-byte equal. This proves the blocklist had
+        // zero effect on `transact_raw` (i.e. the tx executed rather than being
+        // short-circuited), which a bare "no blocklisted error" check cannot distinguish
+        // from the tx simply succeeding.
+        let outcome = |blocklist: FeeCurrencyBlocklist| {
+            let mut evm = make_test_evm(blocklist);
+            format!("{:?}", evm.transact_raw(make_cip64_tx(fc)))
+        };
 
-        let tx = make_cip64_tx(fc);
-        let result = evm.transact_raw(tx);
+        let blocked = FeeCurrencyBlocklist::default();
+        blocked.block_currency(fc, 1000);
 
-        // The tx may still fail for unrelated reasons (no balance, unregistered
-        // currency, …), but it must NOT be rejected with a "blocklisted" error.
-        if let Err(e) = &result {
-            let err_msg = format!("{e}");
-            assert!(
-                !err_msg.contains("blocklisted"),
-                "transact_raw must not reject blocklisted currencies (import safety), got: {err_msg}"
-            );
-        }
+        let with_blocklist = outcome(blocked);
+        let without_blocklist = outcome(FeeCurrencyBlocklist::default());
+
+        assert_eq!(
+            with_blocklist, without_blocklist,
+            "blocklisting a fee currency must not change the transact_raw outcome (import safety)"
+        );
+        assert!(
+            !with_blocklist.contains("blocklisted"),
+            "transact_raw must not reject blocklisted currencies, got: {with_blocklist}"
+        );
     }
 
     #[test]
@@ -636,11 +689,52 @@ mod tests {
         assert!(!blocklist.is_blocked(fc), "Non-debit/credit error should not cause blocklisting");
     }
 
+    /// Block import and derivation re-execute already-canonical blocks and must leave the local
+    /// sequencing blocklist untouched. EVMs created via the factory have `blocklist_enabled`
+    /// off, so `transact_raw` must not evict — a stale entry survives even when the block
+    /// timestamp is well past the eviction window.
+    #[test]
+    fn test_import_mode_does_not_evict_blocklist() {
+        let fc = Address::with_last_byte(0xAA);
+        let blocklist = FeeCurrencyBlocklist::default();
+        blocklist.block_currency(fc, 1000);
+
+        let mut evm = make_test_evm(blocklist.clone());
+        evm.blocklist_enabled = false; // import / derivation EVM
+        // Advance the block far past the eviction window and stay in block-building mode.
+        evm.ctx_mut().block.timestamp = U256::from(1000 + 100_000);
+        evm.ctx_mut().block.basefee = 1_000_000_000;
+
+        let _ = evm.transact_raw(make_cip64_tx(fc));
+
+        assert!(
+            blocklist.is_blocked(fc),
+            "import-mode EVM must not evict (or otherwise mutate) the blocklist"
+        );
+    }
+
+    /// The sequencing path enables the blocklist, so `transact_raw` evicts stale entries using
+    /// the current block timestamp. Counterpart to `test_import_mode_does_not_evict_blocklist`.
+    #[test]
+    fn test_sequencing_mode_evicts_stale_blocklist() {
+        let fc = Address::with_last_byte(0xAA);
+        let blocklist = FeeCurrencyBlocklist::default();
+        blocklist.block_currency(fc, 1000);
+
+        let mut evm = make_test_evm(blocklist.clone()); // blocklist_enabled = true
+        evm.ctx_mut().block.timestamp = U256::from(1000 + 100_000);
+        evm.ctx_mut().block.basefee = 1_000_000_000;
+
+        let _ = evm.transact_raw(make_cip64_tx(fc));
+
+        assert!(!blocklist.is_blocked(fc), "sequencing EVM should evict stale blocklist entries");
+    }
+
     /// Verify that RPC simulation paths (eth_call / eth_estimateGas / debug_trace*)
     /// never store CIP-64 receipt data. Storage is per-EVM, so cross-EVM
     /// corruption is impossible — but multi-tx tracing (`debug_traceBlock`,
     /// `debug_traceTransaction`) re-executes multiple txs through one EVM
-    /// without calling `build_receipt`. Without the `is_block_building` gate
+    /// without calling `build_receipt`. Without the `base_fee_check_enabled` gate
     /// in `transact_raw`, the second CIP-64 tx would trip the slot-occupied
     /// panic in `store_cip64_info` on perfectly legitimate RPC paths.
     ///
@@ -667,7 +761,7 @@ mod tests {
         // Native-fee CIP-64 tx (`fee_currency = 0x0`): the handler sets
         // `cip64_tx_info = Some(..)` on this path even when base fee is
         // disabled, so the only line of defense against polluting the slot is
-        // the `is_block_building` gate in `transact_raw`.
+        // the `base_fee_check_enabled` gate in `transact_raw`.
         let mut tx = make_cip64_tx(Address::ZERO);
         tx.fee_currency = Some(Address::ZERO);
         let result = evm.transact_raw(tx);

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -278,18 +278,14 @@ where
             }
         }
 
-        // Check if the fee currency is blocklisted — reject early without EVM execution.
-        if is_block_building
-            && let Some(fc) = fee_currency
-            && self.blocklist.is_blocked(fc)
-        {
-            return Err(EVMError::Transaction(OpTxError(
-                revm::context::result::InvalidTransaction::from(alloc::format!(
-                    "fee currency {fc} is temporarily blocklisted"
-                ))
-                .into(),
-            )));
-        }
+        // NOTE: blocklist *rejection* is intentionally NOT performed here. `is_block_building`
+        // (= base-fee check enabled) is true during both sequencing AND block import /
+        // derivation re-execution, so rejecting here would let a node's locally-accumulated
+        // blocklist reject a valid canonical block built by another sequencer — a cross-node
+        // disagreement on block validity. Rejection is a sequencing-only policy and is enforced
+        // upstream in `CeloFeeCurrencyFilter` (see `celo-reth`'s `payload.rs`), which derivation
+        // deliberately bypasses. Here we only *populate* the blocklist on debit/credit failures
+        // below; that population is harmless during import (valid blocks never fail debit/credit).
 
         let result = if self.inspect { self.inner.inspect_tx(tx) } else { self.inner.transact(tx) }
             .map_err(map_op_err);
@@ -546,8 +542,14 @@ mod tests {
         }
     }
 
+    /// `transact_raw` must NOT reject a blocklisted currency: `is_block_building`
+    /// (base-fee check enabled) is also true during block import / derivation
+    /// re-execution, so rejecting here would let a node's locally-accumulated
+    /// blocklist reject a valid canonical block. Sequencing-time rejection lives in
+    /// `CeloFeeCurrencyFilter` (see `celo-reth`'s `payload.rs`,
+    /// `filter_skips_blocklisted_currency`), which derivation deliberately bypasses.
     #[test]
-    fn test_blocklist_rejects_in_block_mode() {
+    fn test_blocklist_does_not_reject_in_transact_raw() {
         let fc = Address::with_last_byte(0xAA);
         let blocklist = FeeCurrencyBlocklist::default();
         blocklist.block_currency(fc, 1000);
@@ -557,10 +559,15 @@ mod tests {
         let tx = make_cip64_tx(fc);
         let result = evm.transact_raw(tx);
 
-        // The blocklisted currency should be rejected
-        assert!(result.is_err(), "Expected blocklisted currency to be rejected");
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(err_msg.contains("blocklisted"), "Error should mention blocklist, got: {err_msg}");
+        // The tx may still fail for unrelated reasons (no balance, unregistered
+        // currency, …), but it must NOT be rejected with a "blocklisted" error.
+        if let Err(e) = &result {
+            let err_msg = format!("{e}");
+            assert!(
+                !err_msg.contains("blocklisted"),
+                "transact_raw must not reject blocklisted currencies (import safety), got: {err_msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/alloy-celo-evm/src/lib.rs
+++ b/crates/alloy-celo-evm/src/lib.rs
@@ -175,9 +175,6 @@ pub struct CeloEvm<DB: Database, I, P = CeloPrecompiles> {
     /// `CeloEvmConfig::builder_for_next_block` — the one entry point reth routes sequencing
     /// through (the payload builder), and which import/derivation deliberately bypass.
     blocklist_enabled: bool,
-    /// Block timestamp of the last eviction call, used to avoid redundant eviction
-    /// on every `transact_raw` call within the same block.
-    last_evicted_timestamp: u64,
 }
 
 impl<DB: Database, I, P> CeloEvm<DB, I, P> {
@@ -223,7 +220,6 @@ impl<DB: Database, I, P> CeloEvm<DB, I, P> {
             cip64_storage: Cip64Storage::default(),
             blocklist: FeeCurrencyBlocklist::default(),
             blocklist_enabled: false,
-            last_evicted_timestamp: 0,
         }
     }
 
@@ -299,25 +295,17 @@ where
         // derivation re-execution and RPC. Import and derivation therefore neither read nor write
         // it. (The `base_fee_check_enabled` conjunct is redundant given `blocklist_enabled` but
         // kept as an explicit guard against ever enabling the blocklist on an RPC-simulation EVM.)
-        let apply_blocklist = self.blocklist_enabled && base_fee_check_enabled;
-
-        // Evict stale blocklist entries using the current block timestamp,
-        // but only once per block to avoid redundant work on every transaction.
-        if apply_blocklist {
-            let block_timestamp: u64 = self.ctx().block.timestamp.to();
-            if block_timestamp != self.last_evicted_timestamp {
-                self.blocklist.evict(block_timestamp);
-                self.last_evicted_timestamp = block_timestamp;
-            }
-        }
-
+        //
         // NOTE: blocklist *rejection* is intentionally NOT performed here even on the sequencing
         // path; it is enforced upstream in `CeloFeeCurrencyFilter` (see `celo-reth`'s
         // `payload.rs`). Performing it here would also catch import/derivation EVMs were
         // `blocklist_enabled` ever set on them, letting a node's locally-accumulated
         // blocklist reject a valid canonical block built by another sequencer. Below we
         // only *populate* the blocklist, and only when `apply_blocklist` holds — so import
-        // and derivation neither read nor write it.
+        // and derivation neither read nor write it. Stale-entry eviction also lives upstream
+        // in `CeloPayloadTransactions::best_transactions`, since that is the one place
+        // `is_blocked` is read.
+        let apply_blocklist = self.blocklist_enabled && base_fee_check_enabled;
 
         let result = if self.inspect { self.inner.inspect_tx(tx) } else { self.inner.transact(tx) }
             .map_err(map_op_err);
@@ -465,7 +453,6 @@ fn make_test_evm(
         // RPC-simulation test additionally disables the base-fee check, which the
         // `base_fee_check_enabled` guard in `transact_raw` still honours independently.
         blocklist_enabled: true,
-        last_evicted_timestamp: 0,
     }
 }
 
@@ -495,7 +482,6 @@ impl CeloEvmFactory {
             // factory and must not touch the blocklist. Sequencing flips it on via
             // `with_blocklist_enabled` in `CeloEvmConfig::builder_for_next_block`.
             blocklist_enabled: false,
-            last_evicted_timestamp: 0,
         }
     }
 }
@@ -687,47 +673,6 @@ mod tests {
         let result = evm.transact_raw(tx);
         assert!(result.is_err(), "Expected tx to fail");
         assert!(!blocklist.is_blocked(fc), "Non-debit/credit error should not cause blocklisting");
-    }
-
-    /// Block import and derivation re-execute already-canonical blocks and must leave the local
-    /// sequencing blocklist untouched. EVMs created via the factory have `blocklist_enabled`
-    /// off, so `transact_raw` must not evict — a stale entry survives even when the block
-    /// timestamp is well past the eviction window.
-    #[test]
-    fn test_import_mode_does_not_evict_blocklist() {
-        let fc = Address::with_last_byte(0xAA);
-        let blocklist = FeeCurrencyBlocklist::default();
-        blocklist.block_currency(fc, 1000);
-
-        let mut evm = make_test_evm(blocklist.clone());
-        evm.blocklist_enabled = false; // import / derivation EVM
-        // Advance the block far past the eviction window and stay in block-building mode.
-        evm.ctx_mut().block.timestamp = U256::from(1000 + 100_000);
-        evm.ctx_mut().block.basefee = 1_000_000_000;
-
-        let _ = evm.transact_raw(make_cip64_tx(fc));
-
-        assert!(
-            blocklist.is_blocked(fc),
-            "import-mode EVM must not evict (or otherwise mutate) the blocklist"
-        );
-    }
-
-    /// The sequencing path enables the blocklist, so `transact_raw` evicts stale entries using
-    /// the current block timestamp. Counterpart to `test_import_mode_does_not_evict_blocklist`.
-    #[test]
-    fn test_sequencing_mode_evicts_stale_blocklist() {
-        let fc = Address::with_last_byte(0xAA);
-        let blocklist = FeeCurrencyBlocklist::default();
-        blocklist.block_currency(fc, 1000);
-
-        let mut evm = make_test_evm(blocklist.clone()); // blocklist_enabled = true
-        evm.ctx_mut().block.timestamp = U256::from(1000 + 100_000);
-        evm.ctx_mut().block.basefee = 1_000_000_000;
-
-        let _ = evm.transact_raw(make_cip64_tx(fc));
-
-        assert!(!blocklist.is_blocked(fc), "sequencing EVM should evict stale blocklist entries");
     }
 
     /// Verify that RPC simulation paths (eth_call / eth_estimateGas / debug_trace*)

--- a/crates/celo-reth/src/lib.rs
+++ b/crates/celo-reth/src/lib.rs
@@ -30,7 +30,7 @@ use op_alloy_consensus::EIP1559ParamError;
 use op_revm::OpSpecId;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{
-    ConfigureEvm, Database, EvmEnv,
+    BlockExecutorForEvm, ConfigureEvm, Database, EvmEnv,
     eth::NextEvmEnvAttributes,
     execute::{BasicBlockBuilder, BlockBuilder, BlockExecutor},
 };
@@ -294,6 +294,27 @@ where
             post_exec_mode: PostExecMode::default(),
         })
     }
+
+    /// Builds a block builder for the next block, i.e. the **sequencing** path: reth routes the
+    /// payload builder through this method, while block import and derivation re-execution build
+    /// their EVMs directly via `evm_with_env` + `create_executor` and never reach it. This is the
+    /// one place that enables the fee currency blocklist (`CeloEvm::with_blocklist_enabled`), so
+    /// blocklist reads/writes are confined to sequencing — import and derivation leave the shared
+    /// blocklist untouched. Otherwise identical to the default `ConfigureEvm` implementation.
+    fn builder_for_next_block<'a, DB: Database + 'a>(
+        &'a self,
+        db: &'a mut revm::database::State<DB>,
+        parent: &'a SealedHeader<<N as NodePrimitives>::BlockHeader>,
+        attributes: Self::NextBlockEnvCtx,
+    ) -> Result<
+        impl BlockBuilder<Primitives = Self::Primitives, Executor = BlockExecutorForEvm<'a, Self, DB>>,
+        Self::Error,
+    > {
+        let evm_env = self.next_evm_env(parent, &attributes)?;
+        let evm = self.evm_with_env(db, evm_env).with_blocklist_enabled();
+        let ctx = self.context_for_next_block(parent, attributes)?;
+        Ok(self.create_block_builder(evm, parent, ctx))
+    }
 }
 
 impl<ChainSpec, N, R> ConfigurePostExecEvm for CeloEvmConfig<ChainSpec, N, R>
@@ -353,7 +374,10 @@ where
         Self::Error,
     > {
         let evm_env = self.next_evm_env(parent, &attributes)?;
-        let evm = self.evm_with_env(db, evm_env);
+        // Next-block (sequencing-side) builder, so enable the blocklist like
+        // `builder_for_next_block`. Dormant on Celo: SDM/post-exec is unscheduled, so this
+        // path is never actually driven.
+        let evm = self.evm_with_env(db, evm_env).with_blocklist_enabled();
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);
         let builder = R::from(evm.cip64_storage().clone());

--- a/crates/celo-reth/src/payload.rs
+++ b/crates/celo-reth/src/payload.rs
@@ -138,6 +138,18 @@ impl OpPayloadTransactions<CeloPoolTx> for CeloPayloadTransactions {
     where
         Pool: TransactionPool<Transaction = CeloPoolTx>,
     {
+        // Evict stale blocklist entries before filtering. The EVM-side eviction in
+        // `CeloEvm::transact_raw` only runs once a tx reaches the executor, so a payload whose
+        // first executable txs all use the stale-blocklisted currency would have them rejected
+        // by `CeloFeeCurrencyFilter` below indefinitely — even past the 7200s TTL. Wall clock
+        // is a safe time source here: block timestamps track wall time within seconds and the
+        // blocklist is a best-effort sequencing heuristic, not consensus state.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.blocklist.evict(now);
+
         let block_gas_limit = pool.block_info().block_gas_limit;
         CeloFeeCurrencyFilter {
             inner: BestPayloadTransactions::new(pool.best_transactions_with_attributes(attr)),


### PR DESCRIPTION
Because the blocklist `Arc` is shared with the executor that validates incoming blocks, a currency a node had locally blocklisted could cause it to reject a valid canonical block built by another sequencer.

- Remove blocklist *rejection* from `CeloEvm::transact_raw`; rejection is
  already enforced upstream in `CeloFeeCurrencyFilter` (sequencing only).
- Add `CeloEvm::blocklist_enabled`, off by default on factory-created EVMs
  (import/derivation/RPC). `CeloEvmConfig::builder_for_next_block` flips
  it on — the one entry point reth routes sequencing through, which
  import and derivation deliberately bypass.
- Gate eviction and population on the flag, so import/derivation neither
  read nor write the shared blocklist. Drop the now-unneeded
  eviction high-water-mark.
