### PR TITLE
fix(celo-reth): set dev-mode eip_1559_params so chain advances past genesis

### DIFF
--- a/crates/celo-reth/src/node.rs
+++ b/crates/celo-reth/src/node.rs
@@ -497,7 +497,7 @@ where
                 transactions: Some(vec![ZERO_L1_FEE_DEPOSIT_TX.into()]),
                 no_tx_pool: None,
                 gas_limit: None,
-                eip_1559_params: None,
+                eip_1559_params: Some(alloy_primitives::B64::ZERO),
                 min_base_fee: Some(0),
             },
         )


### PR DESCRIPTION
The dev-mode payload attributes builder set `eip_1559_params: None`, but the dev genesis activates Holocene at time 0, so the payload builder's `get_holocene_extra_data` returned `NoEIP1559Params` and the chain stalled at block 0, causing every e2e test to time out.

Use `B64::ZERO`, which the encoder treats as "use the chain spec's default base fee params", matching upstream op-reth's dev-mode default.