### PR TITLE
Increase test coverage on the RPC level

### DIFF
--- a/crates/celo-alloy/rpc-types/src/receipt.rs
+++ b/crates/celo-alloy/rpc-types/src/receipt.rs
@@ -11,16 +11,19 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 #[doc(alias = "CeloTxReceipt")]
 pub struct CeloTransactionReceipt {
-    /// Regular eth transaction receipt including deposit receipts
+    /// Regular eth transaction receipt including deposit receipts.
+    ///
+    /// For CIP-64 receipts the FC-denominated base fee is carried inside the inner
+    /// `CeloReceiptEnvelope::Cip64`'s [`CeloCip64Receipt::base_fee`] and serialized
+    /// as `"baseFee"` via that envelope's flattened JSON output. Do not duplicate it
+    /// at this level — two flattened `"baseFee"` keys are an undefined-behavior wire
+    /// shape (RFC 8259 §4) and different clients resolve them inconsistently.
     #[serde(flatten)]
     pub inner:
         alloy_rpc_types_eth::TransactionReceipt<CeloReceiptEnvelope<alloy_rpc_types_eth::Log>>,
     /// L1 block info of the transaction.
     #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
-    /// BaseFee stored in fee currency for fee currency txs.
-    #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
-    pub base_fee: Option<u128>,
 }
 
 impl alloy_network_primitives::ReceiptResponse for CeloTransactionReceipt {
@@ -200,7 +203,6 @@ mod tests {
                 contract_address: None,
             },
             l1_block_info: L1BlockInfo::default(),
-            base_fee: None,
         }
     }
 
@@ -219,14 +221,10 @@ mod tests {
     }
 
     fn fx_receipt_cip64() -> CeloTransactionReceipt {
-        let mut r = wrap_inner(CeloReceiptEnvelope::Cip64(CeloCip64ReceiptWithBloom {
+        wrap_inner(CeloReceiptEnvelope::Cip64(CeloCip64ReceiptWithBloom {
             receipt: CeloCip64Receipt { inner: empty_receipt(), base_fee: Some(0x22a4c71a0) },
             logs_bloom: Bloom::default(),
-        }));
-        // Surface the FC-denominated base fee at the top of the RPC receipt — this is
-        // the field that distinguishes a CIP-64 receipt for clients.
-        r.base_fee = Some(0x22a4c71a0);
-        r
+        }))
     }
 
     const DEPOSIT_RECEIPT_POST_CANYON_INPUT: &str = r#"{
@@ -282,8 +280,21 @@ mod tests {
 
     #[test]
     fn golden_cip64_receipt() {
-        let expected = r#"{"type":"0x7b","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"baseFee":"0x22a4c71a0","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","to":"0x00000000000000000000000000000000deadbeef","contractAddress":null,"baseFee":"0x22a4c71a0"}"#;
+        let expected = r#"{"type":"0x7b","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"baseFee":"0x22a4c71a0","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","to":"0x00000000000000000000000000000000deadbeef","contractAddress":null}"#;
         assert_eq!(serde_json::to_string(&fx_receipt_cip64()).unwrap(), expected);
+    }
+
+    // Invariant lock: the wire output must carry `"baseFee"` exactly once. The previous
+    // shape emitted it twice (inner CIP-64 envelope + outer wrapper field), which is
+    // undefined per RFC 8259 §4 and parsed inconsistently across clients.
+    #[test]
+    fn cip64_receipt_to_string_emits_base_fee_once() {
+        let s = serde_json::to_string(&fx_receipt_cip64()).unwrap();
+        assert_eq!(
+            s.matches("\"baseFee\"").count(),
+            1,
+            "baseFee must appear exactly once in the JSON wire output, got: {s}"
+        );
     }
 
     // Regression lock for 0d5324d7's receipt-side counterpart: deposit RPC receipts

--- a/crates/celo-alloy/rpc-types/src/receipt.rs
+++ b/crates/celo-alloy/rpc-types/src/receipt.rs
@@ -153,6 +153,177 @@ impl From<CeloTransactionReceipt> for CeloReceiptEnvelope<alloy_primitives::Log>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::{Eip658Value, Receipt};
+    use alloy_primitives::{Bloom, address, b256};
+
+    // Golden-byte JSON tests for receipt variants. Same rationale as the tx-side
+    // tests: `serde_json::to_value` round-trips dedupe duplicate keys and miss
+    // omitted-required-field regressions. The deposit-receipt golden directly locks
+    // the wire shape that 0d5324d7's tx-side counterpart depends on
+    // (`depositNonce` + `depositReceiptVersion`).
+    //
+    // Eip2930 and Eip7702 receipts are structurally identical to Eip1559 (same
+    // inner `Receipt<Log>` shape), so we don't add separate goldens for them — the
+    // Eip1559 fixture is the load-bearing case.
+
+    fn sample_block_hash() -> alloy_primitives::B256 {
+        b256!("0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67")
+    }
+    fn sample_tx_hash() -> alloy_primitives::B256 {
+        b256!("0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9")
+    }
+    fn sample_from() -> alloy_primitives::Address {
+        address!("0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3")
+    }
+    fn sample_to() -> alloy_primitives::Address {
+        address!("0x00000000000000000000000000000000deadbeef")
+    }
+
+    fn empty_receipt() -> Receipt<alloy_rpc_types_eth::Log> {
+        Receipt { status: Eip658Value::Eip658(true), cumulative_gas_used: 0xfa0d, logs: vec![] }
+    }
+
+    fn wrap_inner(inner: CeloReceiptEnvelope<alloy_rpc_types_eth::Log>) -> CeloTransactionReceipt {
+        CeloTransactionReceipt {
+            inner: alloy_rpc_types_eth::TransactionReceipt {
+                inner,
+                transaction_hash: sample_tx_hash(),
+                transaction_index: Some(0),
+                block_hash: Some(sample_block_hash()),
+                block_number: Some(0x6cfef89),
+                gas_used: 0xfa0d,
+                effective_gas_price: 0,
+                blob_gas_used: None,
+                blob_gas_price: None,
+                from: sample_from(),
+                to: Some(sample_to()),
+                contract_address: None,
+            },
+            l1_block_info: L1BlockInfo::default(),
+            base_fee: None,
+        }
+    }
+
+    fn fx_receipt_legacy() -> CeloTransactionReceipt {
+        wrap_inner(CeloReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: empty_receipt(),
+            logs_bloom: Bloom::default(),
+        }))
+    }
+
+    fn fx_receipt_eip1559() -> CeloTransactionReceipt {
+        wrap_inner(CeloReceiptEnvelope::Eip1559(ReceiptWithBloom {
+            receipt: empty_receipt(),
+            logs_bloom: Bloom::default(),
+        }))
+    }
+
+    fn fx_receipt_cip64() -> CeloTransactionReceipt {
+        let mut r = wrap_inner(CeloReceiptEnvelope::Cip64(CeloCip64ReceiptWithBloom {
+            receipt: CeloCip64Receipt { inner: empty_receipt(), base_fee: Some(0x22a4c71a0) },
+            logs_bloom: Bloom::default(),
+        }));
+        // Surface the FC-denominated base fee at the top of the RPC receipt — this is
+        // the field that distinguishes a CIP-64 receipt for clients.
+        r.base_fee = Some(0x22a4c71a0);
+        r
+    }
+
+    const DEPOSIT_RECEIPT_POST_CANYON_INPUT: &str = r#"{
+        "blockHash": "0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67",
+        "blockNumber": "0x6cfef89",
+        "contractAddress": null,
+        "cumulativeGasUsed": "0xfa0d",
+        "depositNonce": "0x8a2d11",
+        "effectiveGasPrice": "0x0",
+        "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+        "gasUsed": "0xfa0d",
+        "logs": [],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "status": "0x1",
+        "to": "0x4200000000000000000000000000000000000015",
+        "transactionHash": "0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9",
+        "transactionIndex": "0x0",
+        "type": "0x7e",
+        "l1GasPrice": "0x3ef12787",
+        "l1GasUsed": "0x1177",
+        "l1Fee": "0x5bf1ab43d",
+        "l1BaseFeeScalar": "0x1",
+        "l1BlobBaseFee": "0x600ab8f05e64",
+        "l1BlobBaseFeeScalar": "0x1"
+    }"#;
+
+    fn fx_receipt_deposit_post_canyon() -> CeloTransactionReceipt {
+        serde_json::from_str(DEPOSIT_RECEIPT_POST_CANYON_INPUT).unwrap()
+    }
+
+    fn fx_receipt_deposit_pre_canyon() -> CeloTransactionReceipt {
+        wrap_inner(CeloReceiptEnvelope::Deposit(OpDepositReceiptWithBloom {
+            receipt: OpDepositReceipt {
+                inner: empty_receipt(),
+                deposit_nonce: Some(0x8a2d11),
+                deposit_receipt_version: None,
+            },
+            logs_bloom: Bloom::default(),
+        }))
+    }
+
+    #[test]
+    fn golden_legacy_receipt() {
+        let expected = r#"{"type":"0x0","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","to":"0x00000000000000000000000000000000deadbeef","contractAddress":null}"#;
+        assert_eq!(serde_json::to_string(&fx_receipt_legacy()).unwrap(), expected);
+    }
+
+    #[test]
+    fn golden_eip1559_receipt() {
+        let expected = r#"{"type":"0x2","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","to":"0x00000000000000000000000000000000deadbeef","contractAddress":null}"#;
+        assert_eq!(serde_json::to_string(&fx_receipt_eip1559()).unwrap(), expected);
+    }
+
+    #[test]
+    fn golden_cip64_receipt() {
+        let expected = r#"{"type":"0x7b","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"baseFee":"0x22a4c71a0","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","to":"0x00000000000000000000000000000000deadbeef","contractAddress":null,"baseFee":"0x22a4c71a0"}"#;
+        assert_eq!(serde_json::to_string(&fx_receipt_cip64()).unwrap(), expected);
+    }
+
+    // Regression lock for 0d5324d7's receipt-side counterpart: deposit RPC receipts
+    // must carry `depositNonce` and `depositReceiptVersion`.
+    #[test]
+    fn golden_deposit_receipt_post_canyon() {
+        let expected = r#"{"type":"0x7e","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"depositNonce":"0x8a2d11","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001","to":"0x4200000000000000000000000000000000000015","contractAddress":null,"l1GasPrice":"0x3ef12787","l1GasUsed":"0x1177","l1Fee":"0x5bf1ab43d","l1BaseFeeScalar":"0x1","l1BlobBaseFee":"0x600ab8f05e64","l1BlobBaseFeeScalar":"0x1"}"#;
+        assert_eq!(serde_json::to_string(&fx_receipt_deposit_post_canyon()).unwrap(), expected);
+    }
+
+    // Pre-canyon: `depositReceiptVersion` is None and must be omitted entirely.
+    #[test]
+    fn golden_deposit_receipt_pre_canyon() {
+        let expected = r#"{"type":"0x7e","status":"0x1","cumulativeGasUsed":"0xfa0d","logs":[],"depositNonce":"0x8a2d11","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionHash":"0xb7c74afdeb7c89fb9de2c312f49b38cb7a850ba36e064734c5223a477e83fdc9","transactionIndex":"0x0","blockHash":"0x9e6a0fb7e22159d943d760608cc36a0fb596d1ab3c997146f5b7c55c8c718c67","blockNumber":"0x6cfef89","gasUsed":"0xfa0d","effectiveGasPrice":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","to":"0x00000000000000000000000000000000deadbeef","contractAddress":null}"#;
+        assert_eq!(serde_json::to_string(&fx_receipt_deposit_pre_canyon()).unwrap(), expected);
+    }
+
+    // Maintainer utility: regenerate golden receipt literals when struct field order
+    // changes. Run with `cargo test -p celo-alloy-rpc-types _regenerate_receipt_goldens
+    // -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "generator: re-emit golden receipt literals when struct order changes"]
+    fn _regenerate_receipt_goldens() {
+        for (name, json) in [
+            ("legacy", serde_json::to_string(&fx_receipt_legacy()).unwrap()),
+            ("eip1559", serde_json::to_string(&fx_receipt_eip1559()).unwrap()),
+            ("cip64", serde_json::to_string(&fx_receipt_cip64()).unwrap()),
+            (
+                "deposit_post_canyon",
+                serde_json::to_string(&fx_receipt_deposit_post_canyon()).unwrap(),
+            ),
+            (
+                "deposit_pre_canyon",
+                serde_json::to_string(&fx_receipt_deposit_pre_canyon()).unwrap(),
+            ),
+        ] {
+            eprintln!("GOLDEN[{name}]: {json}");
+        }
+        panic!("regenerator only — copy GOLDEN[...] lines into each golden_*_receipt test literal");
+    }
 
     // <https://github.com/alloy-rs/op-alloy/issues/18>
     #[test]

--- a/crates/celo-alloy/rpc-types/src/transaction.rs
+++ b/crates/celo-alloy/rpc-types/src/transaction.rs
@@ -341,7 +341,258 @@ mod tx_serde {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::address;
+    use alloy_consensus::{
+        SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy, transaction::Recovered,
+    };
+    use alloy_eips::eip2930::AccessList;
+    use alloy_primitives::{Signature, address, b256, bytes};
+    use celo_alloy_consensus::TxCip64;
+    use op_alloy_consensus::TxDeposit;
+
+    // Golden-byte JSON tests assert the exact `serde_json::to_string` output of every
+    // `CeloTxEnvelope` variant. Unlike `to_value`-based round-trips, they catch
+    // duplicate-key regressions (cf. d6c83feb, where flattened CIP-64 + a top-level
+    // helper field both emitted `"feeCurrency"`) and missing-required-field regressions
+    // (cf. 0d5324d7, where deposit RPC responses lacked `nonce` and
+    // `depositReceiptVersion`).
+    //
+    // Field-order caveat: the golden strings reflect struct-declaration order of
+    // `CeloTransactionSerdeHelper` (line 189) and the flattened `CeloTxEnvelope` variant.
+    // Reordering those fields will fail these tests and require regenerating the
+    // expected literals. Use the `_regenerate_goldens` test below to re-emit them.
+
+    fn sample_block_hash() -> B256 {
+        b256!("0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391")
+    }
+    fn sample_signer() -> Address {
+        address!("0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3")
+    }
+    fn sample_to() -> Address {
+        address!("0x00000000000000000000000000000000deadbeef")
+    }
+    fn wrap_envelope(env: CeloTxEnvelope, signer: Address, gas_price: u128) -> CeloTransaction {
+        CeloTransaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: Recovered::new_unchecked(env, signer),
+                block_hash: Some(sample_block_hash()),
+                block_number: Some(1),
+                transaction_index: Some(0),
+                effective_gas_price: Some(gas_price),
+                block_timestamp: None,
+            },
+            deposit_nonce: None,
+            deposit_receipt_version: None,
+        }
+    }
+
+    fn fx_legacy() -> CeloTransaction {
+        let env: CeloTxEnvelope = TxLegacy {
+            chain_id: Some(42220),
+            nonce: 1,
+            gas_price: 100_000_000_000,
+            gas_limit: 21_000,
+            to: sample_to().into(),
+            value: U256::from(1u64),
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+        wrap_envelope(env, sample_signer(), 100_000_000_000)
+    }
+
+    fn fx_eip2930() -> CeloTransaction {
+        let env: CeloTxEnvelope = TxEip2930 {
+            chain_id: 42220,
+            nonce: 2,
+            gas_price: 100_000_000_000,
+            gas_limit: 21_000,
+            to: sample_to().into(),
+            value: U256::from(1u64),
+            access_list: AccessList::default(),
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+        wrap_envelope(env, sample_signer(), 100_000_000_000)
+    }
+
+    fn fx_eip1559() -> CeloTransaction {
+        let env: CeloTxEnvelope = TxEip1559 {
+            chain_id: 42220,
+            nonce: 3,
+            max_fee_per_gas: 100_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            gas_limit: 21_000,
+            to: sample_to().into(),
+            value: U256::from(1u64),
+            access_list: AccessList::default(),
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+        wrap_envelope(env, sample_signer(), 100_000_000_000)
+    }
+
+    fn fx_eip7702() -> CeloTransaction {
+        let env: CeloTxEnvelope = TxEip7702 {
+            chain_id: 42220,
+            nonce: 4,
+            max_fee_per_gas: 100_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            gas_limit: 21_000,
+            to: sample_to(),
+            value: U256::from(1u64),
+            access_list: AccessList::default(),
+            authorization_list: vec![],
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+        wrap_envelope(env, sample_signer(), 100_000_000_000)
+    }
+
+    const CIP64_WITH_FC_INPUT: &str = r#"{"accessList":[],"blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x22d41c3","chainId":"0xa4ec","feeCurrency":"0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","gas":"0x3d97c","gasPrice":"0x22a4c71a0","hash":"0x2403eb8e9dd5230ee0c89e430591b804bb2d4e218af479e07cc8ff0b4c3611e7","input":"0xcac35c7a290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563","maxFeePerGas":"0x315373261","maxPriorityFeePerGas":"0x63e4b","nonce":"0x133","r":"0x9de05cbec31a4fcf01c652408e51c58f82aae6c66513320dd9f06b77abfe1494","s":"0x363706d206c4649165bb27b54e6286cf4cedac8b7fdd78d9cb1e00047240e293","to":"0xa0e9096b8e5ad2701f51ca1cb11684aaad91993a","transactionIndex":"0x6","type":"0x7b","v":"0x1","value":"0x0","yParity":"0x1"}"#;
+
+    fn fx_cip64_with_fc() -> CeloTransaction {
+        serde_json::from_str(CIP64_WITH_FC_INPUT).unwrap()
+    }
+
+    fn fx_cip64_no_fc() -> CeloTransaction {
+        let env: CeloTxEnvelope = TxCip64 {
+            chain_id: 42220,
+            nonce: 5,
+            max_fee_per_gas: 100_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            gas_limit: 21_000,
+            to: sample_to().into(),
+            value: U256::from(1u64),
+            access_list: AccessList::default(),
+            fee_currency: None,
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .into();
+        wrap_envelope(env, sample_signer(), 100_000_000_000)
+    }
+
+    const DEPOSIT_POST_CANYON_INPUT: &str = r#"{"blockHash":"0x9d86bb313ebeedf4f9f82bf8a19b426be656a365648a7c089b618771311db9f9","blockNumber":"0x798ad0b","hash":"0xbc9329afac05556497441e2b3ee4c5d4da7ca0b2a4c212c212d0739e94a24df9","transactionIndex":"0x0","type":"0x7e","nonce":"0x152ea95","input":"0x440a5e200000146b000f79c50000000000000003000000006725333f000000000141e287000000000000000000000000000000000000000000000000000000012439ee7e0000000000000000000000000000000000000000000000000000000063f363e973e96e7145ff001c81b9562cba7b6104eeb12a2bc4ab9f07c27d45cd81a986620000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985","mint":"0x0","sourceHash":"0x04e9a69416471ead93b02f0c279ab11ca0b635db5c1726a56faf22623bafde52","r":"0x0","s":"0x0","v":"0x0","yParity":"0x0","gas":"0xf4240","from":"0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001","to":"0x4200000000000000000000000000000000000015","depositReceiptVersion":"0x1","value":"0x0","gasPrice":"0x0"}"#;
+
+    fn fx_deposit_post_canyon() -> CeloTransaction {
+        serde_json::from_str(DEPOSIT_POST_CANYON_INPUT).unwrap()
+    }
+
+    fn fx_deposit_pre_canyon() -> CeloTransaction {
+        let env: CeloTxEnvelope = TxDeposit {
+            source_hash: b256!(
+                "0x04e9a69416471ead93b02f0c279ab11ca0b635db5c1726a56faf22623bafde52"
+            ),
+            from: address!("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"),
+            to: address!("0x4200000000000000000000000000000000000015").into(),
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 1_000_000,
+            is_system_transaction: false,
+            input: bytes!("0x440a5e20"),
+        }
+        .into();
+        CeloTransaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: Recovered::new_unchecked(
+                    env,
+                    address!("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"),
+                ),
+                block_hash: Some(sample_block_hash()),
+                block_number: Some(1),
+                transaction_index: Some(0),
+                effective_gas_price: Some(0),
+                block_timestamp: None,
+            },
+            deposit_nonce: Some(99),
+            deposit_receipt_version: None,
+        }
+    }
+
+    #[test]
+    fn golden_legacy_tx() {
+        let expected = r#"{"type":"0x0","chainId":"0xa4ec","nonce":"0x1","gasPrice":"0x174876e800","gas":"0x5208","to":"0x00000000000000000000000000000000deadbeef","value":"0x1","input":"0x","r":"0x840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565","s":"0x25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1","v":"0x149fb","hash":"0x8731cdf69bf60003051f802c9492a19712a9cdf69a8288e1a7719a085d8fe192","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x1","transactionIndex":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3"}"#;
+        assert_eq!(serde_json::to_string(&fx_legacy()).unwrap(), expected);
+    }
+
+    #[test]
+    fn golden_eip2930_tx() {
+        let expected = r#"{"type":"0x1","chainId":"0xa4ec","nonce":"0x2","gasPrice":"0x174876e800","gas":"0x5208","to":"0x00000000000000000000000000000000deadbeef","value":"0x1","accessList":[],"input":"0x","r":"0x840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565","s":"0x25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1","yParity":"0x0","v":"0x0","hash":"0x037a7231e6d8311f603d27a2f5f557a79841111537cce8d7e6887e5b69b9cfce","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x1","transactionIndex":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3"}"#;
+        assert_eq!(serde_json::to_string(&fx_eip2930()).unwrap(), expected);
+    }
+
+    #[test]
+    fn golden_eip1559_tx() {
+        let expected = r#"{"type":"0x2","chainId":"0xa4ec","nonce":"0x3","gas":"0x5208","maxFeePerGas":"0x174876e800","maxPriorityFeePerGas":"0x3b9aca00","to":"0x00000000000000000000000000000000deadbeef","value":"0x1","accessList":[],"input":"0x","r":"0x840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565","s":"0x25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1","yParity":"0x0","v":"0x0","hash":"0xa2b40a876c192a188abc12accea27591ca31a0545eea1a5ba8369d04ba0b73b7","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x1","transactionIndex":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","gasPrice":"0x174876e800"}"#;
+        assert_eq!(serde_json::to_string(&fx_eip1559()).unwrap(), expected);
+    }
+
+    #[test]
+    fn golden_eip7702_tx() {
+        let expected = r#"{"type":"0x4","chainId":"0xa4ec","nonce":"0x4","gas":"0x5208","maxFeePerGas":"0x174876e800","maxPriorityFeePerGas":"0x3b9aca00","to":"0x00000000000000000000000000000000deadbeef","value":"0x1","accessList":[],"authorizationList":[],"input":"0x","r":"0x840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565","s":"0x25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1","yParity":"0x0","v":"0x0","hash":"0x7e67dcd0583c475a2f064275334cea277a2c63e7cff44353937a5912478f076f","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x1","transactionIndex":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","gasPrice":"0x174876e800"}"#;
+        assert_eq!(serde_json::to_string(&fx_eip7702()).unwrap(), expected);
+    }
+
+    // Regression test for d6c83feb: prior to that fix, this assertion failed because
+    // `"feeCurrency"` was emitted twice — once from the flattened CIP-64 envelope and
+    // once from a top-level helper field. The `to_value` round-trip in
+    // `can_deserialize_cip64` couldn't see this because `serde_json::Value` dedupes
+    // duplicate JSON keys silently.
+    #[test]
+    fn golden_cip64_tx_with_fee_currency() {
+        let expected = r#"{"type":"0x7b","chainId":"0xa4ec","nonce":"0x133","gas":"0x3d97c","maxFeePerGas":"0x315373261","maxPriorityFeePerGas":"0x63e4b","to":"0xa0e9096b8e5ad2701f51ca1cb11684aaad91993a","value":"0x0","accessList":[],"feeCurrency":"0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72","input":"0xcac35c7a290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563","r":"0x9de05cbec31a4fcf01c652408e51c58f82aae6c66513320dd9f06b77abfe1494","s":"0x363706d206c4649165bb27b54e6286cf4cedac8b7fdd78d9cb1e00047240e293","yParity":"0x1","v":"0x1","hash":"0x2403eb8e9dd5230ee0c89e430591b804bb2d4e218af479e07cc8ff0b4c3611e7","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x22d41c3","transactionIndex":"0x6","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","gasPrice":"0x22a4c71a0"}"#;
+        assert_eq!(serde_json::to_string(&fx_cip64_with_fc()).unwrap(), expected);
+    }
+
+    // CIP-64 with `fee_currency = None` emits `"feeCurrency":null` rather than omitting
+    // the field — locks the wire-shape decision so a future `skip_serializing_if` change
+    // is a deliberate, golden-bumping update rather than an accidental client break.
+    #[test]
+    fn golden_cip64_tx_without_fee_currency() {
+        let expected = r#"{"type":"0x7b","chainId":"0xa4ec","nonce":"0x5","gas":"0x5208","maxFeePerGas":"0x174876e800","maxPriorityFeePerGas":"0x3b9aca00","to":"0x00000000000000000000000000000000deadbeef","value":"0x1","accessList":[],"feeCurrency":null,"input":"0x","r":"0x840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565","s":"0x25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1","yParity":"0x0","v":"0x0","hash":"0xc6475d44bdf6229f48be13bd96e567745558555e7e136dad1dfbbd39d50a3142","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x1","transactionIndex":"0x0","from":"0x7fda9576b9256c5bbe7cc487a0e49da7f038e2f3","gasPrice":"0x174876e800"}"#;
+        assert_eq!(serde_json::to_string(&fx_cip64_no_fc()).unwrap(), expected);
+    }
+
+    // Regression test for 0d5324d7: prior to that fix the deposit-tx serializer omitted
+    // `"nonce"` and `"depositReceiptVersion"` entirely, breaking viem / web3.py / ethers.
+    #[test]
+    fn golden_deposit_tx_post_canyon() {
+        let expected = r#"{"type":"0x7e","sourceHash":"0x04e9a69416471ead93b02f0c279ab11ca0b635db5c1726a56faf22623bafde52","from":"0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001","to":"0x4200000000000000000000000000000000000015","mint":"0x0","value":"0x0","gas":"0xf4240","input":"0x440a5e200000146b000f79c50000000000000003000000006725333f000000000141e287000000000000000000000000000000000000000000000000000000012439ee7e0000000000000000000000000000000000000000000000000000000063f363e973e96e7145ff001c81b9562cba7b6104eeb12a2bc4ab9f07c27d45cd81a986620000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985","hash":"0xbc9329afac05556497441e2b3ee4c5d4da7ca0b2a4c212c212d0739e94a24df9","r":"0x0","s":"0x0","yParity":"0x0","v":"0x0","blockHash":"0x9d86bb313ebeedf4f9f82bf8a19b426be656a365648a7c089b618771311db9f9","blockNumber":"0x798ad0b","transactionIndex":"0x0","depositReceiptVersion":"0x1","gasPrice":"0x0","nonce":"0x152ea95"}"#;
+        assert_eq!(serde_json::to_string(&fx_deposit_post_canyon()).unwrap(), expected);
+    }
+
+    // Pre-canyon deposit: `depositReceiptVersion` is omitted entirely (not null).
+    #[test]
+    fn golden_deposit_tx_pre_canyon() {
+        let expected = r#"{"type":"0x7e","sourceHash":"0x04e9a69416471ead93b02f0c279ab11ca0b635db5c1726a56faf22623bafde52","from":"0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001","to":"0x4200000000000000000000000000000000000015","mint":"0x0","value":"0x0","gas":"0xf4240","input":"0x440a5e20","hash":"0x73bae408587f1f228fad672762f1a219e63f13c415469e14e866a844912b6ec3","r":"0x0","s":"0x0","yParity":"0x0","v":"0x0","blockHash":"0x2a1c29764370aa197a2344507e4573e8bd1fbe757c10bd92e34eb9ad4934f391","blockNumber":"0x1","transactionIndex":"0x0","gasPrice":"0x0","nonce":"0x63"}"#;
+        assert_eq!(serde_json::to_string(&fx_deposit_pre_canyon()).unwrap(), expected);
+    }
+
+    // Maintainer utility: prints fresh golden-byte strings for every fixture. Run with
+    // `cargo test -p celo-alloy-rpc-types _regenerate_goldens -- --ignored --nocapture`
+    // when `CeloTransactionSerdeHelper` field order, the flattened `CeloTxEnvelope`
+    // shape, or any of the underlying tx-type structs change. Always fails so it
+    // doesn't run in normal suites.
+    #[test]
+    #[ignore = "generator: re-emit golden literals when struct order changes"]
+    fn _regenerate_goldens() {
+        for (name, json) in [
+            ("legacy", serde_json::to_string(&fx_legacy()).unwrap()),
+            ("eip2930", serde_json::to_string(&fx_eip2930()).unwrap()),
+            ("eip1559", serde_json::to_string(&fx_eip1559()).unwrap()),
+            ("eip7702", serde_json::to_string(&fx_eip7702()).unwrap()),
+            ("cip64_with_fc", serde_json::to_string(&fx_cip64_with_fc()).unwrap()),
+            ("cip64_no_fc", serde_json::to_string(&fx_cip64_no_fc()).unwrap()),
+            ("deposit_post_canyon", serde_json::to_string(&fx_deposit_post_canyon()).unwrap()),
+            ("deposit_pre_canyon", serde_json::to_string(&fx_deposit_pre_canyon()).unwrap()),
+        ] {
+            eprintln!("GOLDEN[{name}]: {json}");
+        }
+        panic!("regenerator only — copy GOLDEN[...] lines into each golden_* test literal");
+    }
 
     #[test]
     fn can_deserialize_deposit() {

--- a/crates/celo-reth/src/rpc.rs
+++ b/crates/celo-reth/src/rpc.rs
@@ -498,20 +498,18 @@ impl<Provider> CeloReceiptConverter<Provider> {
         });
 
         // For CIP-64 receipts, fix effective_gas_price using the FC-denominated base fee
-        // instead of the native CELO base fee that `build_receipt` used.
-        let base_fee = if let CeloReceiptEnvelope::Cip64(ref cip64) = core_receipt.inner {
-            let fc_base_fee = cip64.receipt.base_fee;
-            if let Some(fc_bf) = fc_base_fee {
-                core_receipt.effective_gas_price = cip64_effective_gas_price(
-                    tx_signed.max_fee_per_gas(),
-                    tx_signed.max_priority_fee_per_gas().unwrap_or(0),
-                    fc_bf,
-                );
-            }
-            fc_base_fee
-        } else {
-            None
-        };
+        // instead of the native CELO base fee that `build_receipt` used. The FC base fee
+        // itself is already carried inside the inner `CeloCip64Receipt` and serialized as
+        // `"baseFee"` via the flattened envelope — no separate outer field needed.
+        if let CeloReceiptEnvelope::Cip64(ref cip64) = core_receipt.inner &&
+            let Some(fc_bf) = cip64.receipt.base_fee
+        {
+            core_receipt.effective_gas_price = cip64_effective_gas_price(
+                tx_signed.max_fee_per_gas(),
+                tx_signed.max_priority_fee_per_gas().unwrap_or(0),
+                fc_bf,
+            );
+        }
 
         // In Jovian, blob_gas_used is repurposed to store the DA footprint value,
         // matching the upstream OpReceiptBuilder logic.
@@ -526,11 +524,7 @@ impl<Provider> CeloReceiptConverter<Provider> {
             .l1_block_info(chain_spec, tx_signed, l1_block_info)?
             .build();
 
-        Ok(CeloTransactionReceipt {
-            inner: core_receipt,
-            l1_block_info: op_fields.l1_block_info,
-            base_fee,
-        })
+        Ok(CeloTransactionReceipt { inner: core_receipt, l1_block_info: op_fields.l1_block_info })
     }
 }
 
@@ -1602,10 +1596,10 @@ mod tests {
                 blob_gas_used: None,
             },
             l1_block_info: Default::default(),
-            base_fee: Some(fc_base_fee),
         };
 
-        let json = serde_json::to_value(&receipt).unwrap();
+        let json_str = serde_json::to_string(&receipt).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         // type must be 0x7b (CIP-64), not 0x2 (EIP-1559)
         assert_eq!(json["type"], "0x7b", "CIP-64 receipt type must be 0x7b");
@@ -1615,6 +1609,13 @@ mod tests {
             json["baseFee"],
             format!("0x{fc_base_fee:x}"),
             "baseFee must be the FC-denominated base fee"
+        );
+
+        // baseFee must appear exactly once on the wire (no duplicate-key regression).
+        assert_eq!(
+            json_str.matches("\"baseFee\"").count(),
+            1,
+            "baseFee must appear exactly once in the wire output, got: {json_str}"
         );
 
         // effectiveGasPrice must reflect the FC-denominated price
@@ -1714,8 +1715,10 @@ mod tests {
         }"#;
 
         let receipt: CeloTransactionReceipt = serde_json::from_str(json).unwrap();
-        assert_eq!(receipt.base_fee, Some(500_000_000));
-        assert!(matches!(receipt.inner.inner, CeloReceiptEnvelope::Cip64(_)));
+        let CeloReceiptEnvelope::Cip64(ref cip64) = receipt.inner.inner else {
+            panic!("expected CIP-64 receipt envelope");
+        };
+        assert_eq!(cip64.receipt.base_fee, Some(500_000_000));
     }
 
     #[test]
@@ -1921,16 +1924,21 @@ mod tests {
                 blob_gas_used: None,
             },
             l1_block_info: Default::default(),
-            base_fee: Some(fc_base_fee),
         };
 
-        let json = serde_json::to_value(&receipt).unwrap();
+        let json_str = serde_json::to_string(&receipt).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
         // Verify type is CIP-64 (0x7b)
         assert_eq!(json["type"], "0x7b");
 
-        // Verify baseFee is present
+        // Verify baseFee is present and unique on the wire (no duplicate-key regression).
         assert!(json["baseFee"].is_string(), "baseFee should be present for CIP-64 receipts");
+        assert_eq!(
+            json_str.matches("\"baseFee\"").count(),
+            1,
+            "baseFee must appear exactly once in the wire output, got: {json_str}"
+        );
 
         // Verify baseFee value
         let base_fee_hex = json["baseFee"].as_str().unwrap();

--- a/e2e_test/js-tests/test_viem_smoketest.mjs
+++ b/e2e_test/js-tests/test_viem_smoketest.mjs
@@ -1,8 +1,11 @@
 import { assert } from "chai";
 import "mocha";
 import {
+	createWalletClient,
+	http,
 	parseAbi,
 } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import fs from "fs";
 import { publicClient, walletClient } from "./viem_setup.mjs"
 
@@ -156,14 +159,25 @@ describe("viem smoke test, deposit tx (block 1 L1-attributes)", () => {
 // an authorizationList and cannot be a contract-create), so it gets its own
 // describe block rather than joining the iteration above. Skipping its
 // require-fields schema would miss the `authorizationList` regression class.
+//
+// IMPORTANT: the authorization is signed by a throwaway account, not the
+// funded test wallet. Signing with `executor: "self"` would delegate the
+// test wallet's own EOA to the target address — that delegation persists
+// on-chain across tests, and the celo-reth pool then rejects any later
+// gapped-nonce txs from the funded account as "gapped-nonce tx from
+// delegated accounts" (e.g. test_viem_tx.mjs:testNonceBump). Delegating a
+// fresh random EOA leaves the funded account a plain EOA.
 describe("viem smoke test, tx type eip7702", () => {
 	let l1Fee = 0n;
 	it("send tx with authorization", async () => {
-		// Delegate to a fixed non-contract address; viem signs the authorization
-		// over the account itself, no on-chain code is required to exist there.
-		const authorization = await walletClient.signAuthorization({
+		const authority = privateKeyToAccount(generatePrivateKey());
+		const authorityWallet = createWalletClient({
+			account: authority,
+			chain: publicClient.chain,
+			transport: http(process.env.ETH_RPC_URL),
+		});
+		const authorization = await authorityWallet.signAuthorization({
 			contractAddress: "0x00000000000000000000000000000000DeaDBeef",
-			executor: "self",
 		});
 		const send = await walletClient.sendTransaction({
 			to: "0x00000000000000000000000000000000DeaDBeef",

--- a/e2e_test/js-tests/test_viem_smoketest.mjs
+++ b/e2e_test/js-tests/test_viem_smoketest.mjs
@@ -23,6 +23,7 @@ const REQUIRED_TX_FIELDS_BY_TYPE = {
 	legacy: ["chainId", "gasPrice"],
 	eip2930: ["chainId", "gasPrice", "accessList"],
 	eip1559: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList"],
+	eip7702: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList", "authorizationList"],
 	cip64: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList", "feeCurrency"],
 };
 const REQUIRED_RECEIPT_FIELDS_COMMON = [
@@ -115,5 +116,28 @@ async function sendTypedCreateTransaction(type, feeCurrency) {
 			const contract = await sendTypedSmartContractTransaction(type, feeCurrency);
 			await check(contract, {type, feeCurrency}, {l1Fee});
 		});
+	});
+});
+
+// EIP-7702 has a different send shape (no plain transfer template — it needs
+// an authorizationList and cannot be a contract-create), so it gets its own
+// describe block rather than joining the iteration above. Skipping its
+// require-fields schema would miss the `authorizationList` regression class.
+describe("viem smoke test, tx type eip7702", () => {
+	let l1Fee = 0n;
+	it("send tx with authorization", async () => {
+		// Delegate to a fixed non-contract address; viem signs the authorization
+		// over the account itself, no on-chain code is required to exist there.
+		const authorization = await walletClient.signAuthorization({
+			contractAddress: "0x00000000000000000000000000000000DeaDBeef",
+			executor: "self",
+		});
+		const send = await walletClient.sendTransaction({
+			to: "0x00000000000000000000000000000000DeaDBeef",
+			value: 1,
+			type: "eip7702",
+			authorizationList: [authorization],
+		});
+		await check(send, {type: "eip7702"}, {l1Fee});
 	});
 });

--- a/e2e_test/js-tests/test_viem_smoketest.mjs
+++ b/e2e_test/js-tests/test_viem_smoketest.mjs
@@ -9,9 +9,40 @@ import { publicClient, walletClient } from "./viem_setup.mjs"
 // Load compiled contract
 const testContractJSON = JSON.parse(fs.readFileSync(process.env.COMPILED_TEST_CONTRACT, 'utf8'));
 
+// Required-field schemas for each tx type, derived from what a real client
+// (viem/web3.py/ethers) treats as mandatory when parsing eth_getTransactionByHash
+// / eth_getTransactionReceipt responses. Regressions of d6c83feb (duplicate
+// feeCurrency) and 0d5324d7 (missing nonce/depositReceiptVersion) bypassed the
+// existing assertions because viem returned undefined on the missing fields and
+// nothing checked. These tables make those failures explicit.
+const REQUIRED_TX_FIELDS_COMMON = [
+	"hash", "nonce", "from", "gas", "input", "value",
+	"r", "s", "blockHash", "blockNumber", "transactionIndex", "type",
+];
+const REQUIRED_TX_FIELDS_BY_TYPE = {
+	legacy: ["chainId", "gasPrice"],
+	eip2930: ["chainId", "gasPrice", "accessList"],
+	eip1559: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList"],
+	cip64: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList", "feeCurrency"],
+};
+const REQUIRED_RECEIPT_FIELDS_COMMON = [
+	"transactionHash", "transactionIndex", "blockHash", "blockNumber",
+	"from", "cumulativeGasUsed", "gasUsed", "logs", "logsBloom",
+	"status", "effectiveGasPrice", "type",
+];
+
+function assertFieldsPresent(obj, fields, label) {
+	for (const field of fields) {
+		assert.isDefined(obj[field], `${label} missing required field '${field}'`);
+		assert.isNotNull(obj[field], `${label} required field '${field}' is null`);
+	}
+}
+
 // check checks that the receipt has status success and that the transaction
 // type matches the expected type, since viem sometimes mangles the type when
-// building txs.
+// building txs. It also enforces that every field a real client requires for
+// the given tx type is present and non-null in both the tx and receipt
+// responses — see REQUIRED_TX_FIELDS_BY_TYPE for the per-type schema.
 async function check(txHash, tx_checks, receipt_checks) {
 	const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
 	assert.equal(receipt.status, "success", "receipt status 'failure'");
@@ -21,6 +52,12 @@ async function check(txHash, tx_checks, receipt_checks) {
 	}
 	for (const [key, expected] of Object.entries(receipt_checks ?? {})) {
 		assert.equal(receipt[key], expected, `receipt ${key} does not match`);
+	}
+	const type = tx_checks?.type;
+	if (type && REQUIRED_TX_FIELDS_BY_TYPE[type]) {
+		assertFieldsPresent(transaction, REQUIRED_TX_FIELDS_COMMON, `tx[${type}]`);
+		assertFieldsPresent(transaction, REQUIRED_TX_FIELDS_BY_TYPE[type], `tx[${type}]`);
+		assertFieldsPresent(receipt, REQUIRED_RECEIPT_FIELDS_COMMON, `receipt[${type}]`);
 	}
 }
 

--- a/e2e_test/js-tests/test_viem_smoketest.mjs
+++ b/e2e_test/js-tests/test_viem_smoketest.mjs
@@ -25,6 +25,10 @@ const REQUIRED_TX_FIELDS_BY_TYPE = {
 	eip1559: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList"],
 	eip7702: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList", "authorizationList"],
 	cip64: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList", "feeCurrency"],
+	// Deposit (type 0x7e) is sequencer-built; clients only read it. Required-fields
+	// schema locks the regression of 0d5324d7 (missing nonce + depositReceiptVersion)
+	// on the read path. `to` is also required: deposits target a contract address.
+	deposit: ["sourceHash", "mint", "isSystemTransaction"],
 };
 const REQUIRED_RECEIPT_FIELDS_COMMON = [
 	"transactionHash", "transactionIndex", "blockHash", "blockNumber",
@@ -116,6 +120,23 @@ async function sendTypedCreateTransaction(type, feeCurrency) {
 			const contract = await sendTypedSmartContractTransaction(type, feeCurrency);
 			await check(contract, {type, feeCurrency}, {l1Fee});
 		});
+	});
+});
+
+// Deposit txs (type 0x7e) can't be sent from a wallet — they're sequencer-built
+// from L1 attributes. Dev-mode payload builder always inserts an L1-attributes
+// deposit as the first transaction of block 1 (see crates/celo-reth/src/node.rs
+// dev-mode payload attributes builder). Fetching it and running the same
+// required-fields schema covers the read-side regression class of 0d5324d7.
+describe("viem smoke test, deposit tx (block 1 L1-attributes)", () => {
+	it("read-side required fields present", async () => {
+		const block = await publicClient.getBlock({ blockNumber: 1n, includeTransactions: true });
+		const deposit = block.transactions.find((t) => t.type === "deposit");
+		assert.isDefined(deposit, "block 1 has no deposit tx (dev-mode L1-attributes missing)");
+		assertFieldsPresent(deposit, REQUIRED_TX_FIELDS_COMMON, "tx[deposit]");
+		assertFieldsPresent(deposit, REQUIRED_TX_FIELDS_BY_TYPE.deposit, "tx[deposit]");
+		const receipt = await publicClient.getTransactionReceipt({ hash: deposit.hash });
+		assertFieldsPresent(receipt, REQUIRED_RECEIPT_FIELDS_COMMON, "receipt[deposit]");
 	});
 });
 

--- a/e2e_test/js-tests/test_viem_smoketest.mjs
+++ b/e2e_test/js-tests/test_viem_smoketest.mjs
@@ -27,8 +27,8 @@ const REQUIRED_TX_FIELDS_BY_TYPE = {
 	cip64: ["chainId", "maxFeePerGas", "maxPriorityFeePerGas", "accessList", "feeCurrency"],
 	// Deposit (type 0x7e) is sequencer-built; clients only read it. Required-fields
 	// schema locks the regression of 0d5324d7 (missing nonce + depositReceiptVersion)
-	// on the read path. `to` is also required: deposits target a contract address.
-	deposit: ["sourceHash", "mint", "isSystemTransaction"],
+	// on the read path. `nonce` is covered by REQUIRED_TX_FIELDS_COMMON.
+	deposit: ["sourceHash", "mint", "depositReceiptVersion"],
 };
 const REQUIRED_RECEIPT_FIELDS_COMMON = [
 	"transactionHash", "transactionIndex", "blockHash", "blockNumber",
@@ -128,14 +128,26 @@ async function sendTypedCreateTransaction(type, feeCurrency) {
 // deposit as the first transaction of block 1 (see crates/celo-reth/src/node.rs
 // dev-mode payload attributes builder). Fetching it and running the same
 // required-fields schema covers the read-side regression class of 0d5324d7.
+//
+// Use raw eth_getBlockByNumber rather than publicClient.getBlock: viem's celo
+// block formatter calls the *standard* formatTransaction for entries inside
+// blocks, which doesn't know about type 0x7e and drops deposit-specific fields.
+// The whole point of the field-presence assertion is what the node actually
+// emits on the wire, so we want the unformatted JSON here anyway.
 describe("viem smoke test, deposit tx (block 1 L1-attributes)", () => {
 	it("read-side required fields present", async () => {
-		const block = await publicClient.getBlock({ blockNumber: 1n, includeTransactions: true });
-		const deposit = block.transactions.find((t) => t.type === "deposit");
+		const block = await publicClient.request({
+			method: "eth_getBlockByNumber",
+			params: ["0x1", true],
+		});
+		const deposit = block.transactions.find((t) => t.type === "0x7e");
 		assert.isDefined(deposit, "block 1 has no deposit tx (dev-mode L1-attributes missing)");
 		assertFieldsPresent(deposit, REQUIRED_TX_FIELDS_COMMON, "tx[deposit]");
 		assertFieldsPresent(deposit, REQUIRED_TX_FIELDS_BY_TYPE.deposit, "tx[deposit]");
-		const receipt = await publicClient.getTransactionReceipt({ hash: deposit.hash });
+		const receipt = await publicClient.request({
+			method: "eth_getTransactionReceipt",
+			params: [deposit.hash],
+		});
 		assertFieldsPresent(receipt, REQUIRED_RECEIPT_FIELDS_COMMON, "receipt[deposit]");
 	});
 });


### PR DESCRIPTION
I went through recently found bugs and tried to add tests to prevent regressions and detect or prevent similar bugs.

The only new bug I found doing this is a duplicate serialization of the `baseFee`, fixed in 0ea0f232fc7b1cbe2704c005aecf1da08b65c660.