### PR TITLE
ci: run e2e_test/run_all_tests.sh on every PR

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -107,6 +107,35 @@ jobs:
       - name: cargo hack
         run: just hack
 
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    name: e2e-tests
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          prefix-key: e2e
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1.4.0
+        with:
+          version: v1.1.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: e2e_test/js-tests/package-lock.json
+      - name: Run e2e tests
+        run: e2e_test/run_all_tests.sh
+      - name: Upload celo-reth log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: celo-reth-log
+          path: e2e_test/celo-reth.log
+          if-no-files-found: ignore
+
   check-no-std:
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Mirrors op-geth's CI job: install Foundry + Node, then run the dev-mode celo-reth and exercise the e2e shell tests so fee-currency, token duality, and JS client (viem/ethers) regressions surface in CI rather than locally.