### PR TITLE
ci: split units_compile_fail into a post-merge job

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -30,6 +30,26 @@ jobs:
       - name: cargo test
         run: just test
 
+  # The trybuild compile-fail guard for `celo_revm::units` (see
+  # `crates/celo-reth/tests/units_compile_fail.rs`) recompiles the full
+  # dep tree once per UI fixture in a trybuild-managed sub-target, which
+  # routinely pushes past the main `test` job's 40-minute budget. Run it
+  # in its own job, only on push to main, so PRs aren't blocked on it.
+  trybuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    name: trybuild
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          components: rustfmt
+      - uses: taiki-e/install-action@nextest
+      - name: cargo test (trybuild)
+        run: just test-trybuild
+
   cargo-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/Justfile
+++ b/Justfile
@@ -21,9 +21,17 @@ default:
 setup:
   git config core.hooksPath .githooks
 
-# Test for the native target with all features.
+# Test for the native target with all features. Excludes the slow trybuild
+# compile-fail guard (see `test-trybuild`).
 test:
-  cargo nextest run --workspace --all-features {{exclude_members}}
+  cargo nextest run --workspace --all-features {{exclude_members}} -E 'not binary(units_compile_fail)'
+
+# Slow trybuild compile-fail guard for `celo_revm::units` mixed-denomination
+# defenses. Each UI fixture triggers a fresh from-scratch compile in a
+# trybuild-managed sub-target, so this is split off from `just test` and only
+# runs in CI post-merge to main.
+test-trybuild:
+  cargo nextest run -p celo-reth --test units_compile_fail
 
 # Runs benchmarks
 benches:


### PR DESCRIPTION
The trybuild compile-fail guard for `celo_revm::units` compiles the full dep tree once per UI fixture in a trybuild-managed sub-target. On CI it takes ~7-14 minutes by itself and recently pushed the main `test` job past its 40-minute timeout (run 26890764971).

Filter it out of `just test` via a nextest binary expression and add a `just test-trybuild` recipe plus a dedicated `trybuild` CI job gated to push-on-main, so PRs aren't blocked on it.

Alternatively, we could completely drop it if it is too resource intensive. It is not that likely to brake.