### PR TITLE
Espresso derivation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "canoe-bindings"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-sol-types",
  "serde",
@@ -1941,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "canoe-verifier"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "canoe-verifier-address-fetcher"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-primitives",
  "eigenda-cert",
@@ -2088,6 +2088,7 @@ dependencies = [
  "alloy-celo-evm",
  "alloy-consensus",
  "alloy-primitives",
+ "celo-derive",
  "celo-driver",
  "celo-genesis",
  "celo-proof",
@@ -2102,6 +2103,26 @@ dependencies = [
  "kona-proof",
  "kona-std-fpvm",
  "kona-std-fpvm-proc",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "celo-derive"
+version = "1.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.4",
+ "alloy-primitives",
+ "alloy-rlp",
+ "async-trait",
+ "celo-genesis",
+ "kona-derive",
+ "kona-genesis",
+ "kona-protocol",
+ "lru",
+ "tokio",
  "tracing",
 ]
 
@@ -3360,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "eigenda-cert"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4259,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -4281,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "hokulea-client-bin"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-evm",
  "alloy-op-evm",
@@ -4302,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "hokulea-eigenda"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4318,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "hokulea-host-bin"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-op-evm",
  "alloy-primitives",
@@ -4346,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "hokulea-proof"
 version = "0.1.0"
-source = "git+https://github.com/celo-org/hokulea?rev=b717a24bc6f95f196fc2515add000c1b091ee5ff#b717a24bc6f95f196fc2515add000c1b091ee5ff"
+source = "git+https://github.com/celo-org/hokulea?rev=fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6#fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6"
 dependencies = [
  "alloy-primitives",
  "ark-bn254",
@@ -5308,8 +5329,10 @@ dependencies = [
  "kona-protocol",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
+ "spin 0.10.0",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ celo-alloy-rpc-types = { version = "1.0.0", path = "crates/celo-alloy/rpc-types"
 celo-alloy-network = { version = "1.0.0", path = "crates/celo-alloy/network", default-features = false }
 alloy-celo-evm = { version = "1.0.0", path = "crates/alloy-celo-evm", default-features = false }
 celo-executor = { version = "1.0.0", path = "crates/kona/executor", default-features = false }
+celo-derive = { version = "1.0.0", path = "crates/kona/derive", default-features = false }
 celo-driver = { version = "1.0.0", path = "crates/kona/driver", default-features = false }
 celo-proof = { version = "1.0.0", path = "crates/kona/proof", default-features = false }
 celo-protocol = { version = "1.0.0", path = "crates/kona/protocol", default-features = false }
@@ -200,12 +201,15 @@ reth-optimism-trie = { git = "https://github.com/ethereum-optimism/optimism", ta
 reth-optimism-txpool = { git = "https://github.com/ethereum-optimism/optimism", tag = "kona-node/v1.5.1" }
 
 # Hokulea
-# celo-org/hokulea karlb/version-bump — fork pinned at the kona-node/v1.5.1
-# bump (commit b717a24). Switch back to upstream Layr-Labs/hokulea once
-# a hokulea-client release with v1.5.x support is cut.
-hokulea-eigenda = { git = "https://github.com/celo-org/hokulea", rev = "b717a24bc6f95f196fc2515add000c1b091ee5ff", default-features = false }
-hokulea-proof = { git = "https://github.com/celo-org/hokulea", rev = "b717a24bc6f95f196fc2515add000c1b091ee5ff", default-features = false }
-hokulea-host-bin = { git = "https://github.com/celo-org/hokulea", rev = "b717a24bc6f95f196fc2515add000c1b091ee5ff", default-features = false }
+# celo-org/hokulea — pinned at the kona-node/v1.5.1 bump (commit b717a24) plus
+# the EigenDADataSource generalization over DataAvailabilityProvider (commit
+# fccc98c, celo-org/hokulea#2), which lets the eigenda path wrap celo-kona's
+# CeloEthereumDataSource (Espresso batch auth). Bump to the merged commit once
+# celo-org/hokulea#2 lands. Switch back to upstream Layr-Labs/hokulea once a
+# hokulea-client release with v1.5.x support and the generalized data source is cut.
+hokulea-eigenda = { git = "https://github.com/celo-org/hokulea", rev = "fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6", default-features = false }
+hokulea-proof = { git = "https://github.com/celo-org/hokulea", rev = "fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6", default-features = false }
+hokulea-host-bin = { git = "https://github.com/celo-org/hokulea", rev = "fccc98c2d2fa1549bb0dce55d9dbf21a5c3026f6", default-features = false }
 
 # General
 url = { version = "2.5.8", default-features = false }
@@ -225,6 +229,7 @@ anyhow = { version = "1.0.101", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }
 derive_more = { version = "2.1.1", default-features = false }
 lazy_static = { version = "1.5.0", default-features = false }
+lru = { version = "0.16.4", default-features = false }
 
 bytes = { version = "1.11.0", default-features = false }
 eyre = "0.6.12"

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 alloy-celo-evm.workspace = true
 celo-proof.workspace = true
 celo-driver.workspace = true
+celo-derive.workspace = true
 celo-genesis = { workspace = true, features = ["serde"] }
 celo-protocol.workspace = true
 
@@ -40,6 +41,8 @@ hokulea-proof = { workspace = true, optional = true }
 # General
 cfg-if.workspace = true
 tracing.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 kona-preimage = { workspace = true, features = ["std"] }

--- a/bin/client/src/single.rs
+++ b/bin/client/src/single.rs
@@ -4,6 +4,7 @@ use alloc::sync::Arc;
 use alloy_celo_evm::CeloEvmFactory;
 use alloy_consensus::Sealed;
 use alloy_primitives::B256;
+use celo_derive::CeloEthereumDataSource;
 use celo_driver::CeloDriver;
 use celo_genesis::CeloRollupConfig;
 use celo_proof::{CeloBootInfo, CeloOracleL2ChainProvider, executor::CeloExecutor};
@@ -14,7 +15,6 @@ use hokulea_eigenda::{EigenDADataSource, EigenDAPreimageSource};
 #[cfg(feature = "eigenda")]
 use hokulea_proof::eigenda_provider::OracleEigenDAPreimageProvider;
 use kona_client::single::FaultProofProgramError;
-use kona_derive::EthereumDataSource;
 use kona_executor::TrieDBProvider;
 use kona_preimage::{CommsClient, HintWriterClient, PreimageKey, PreimageOracleClient};
 use kona_proof::{
@@ -42,8 +42,10 @@ where
         Arc::new(CachingOracle::new(ORACLE_LRU_SIZE, oracle_client.clone(), hint_client.clone()));
     let boot = CeloBootInfo::load(oracle.as_ref()).await?;
 
-    // Wrap RollupConfig to CeloRollupConfig
-    let celo_rollup_config = CeloRollupConfig(boot.op_boot_info.rollup_config.clone());
+    // Wrap RollupConfig to CeloRollupConfig, carrying the Espresso batch-authentication settings
+    // resolved during boot.
+    let mut celo_rollup_config = CeloRollupConfig::new(boot.op_boot_info.rollup_config.clone());
+    celo_rollup_config.espresso = boot.espresso;
     let celo_rollup_config = Arc::new(celo_rollup_config);
 
     let rollup_config = Arc::new(boot.op_boot_info.rollup_config);
@@ -98,8 +100,15 @@ where
     let l1_config = Arc::new(boot.op_boot_info.l1_config);
 
     // Set up data source and build the pipeline.
-    let eth_data_source =
-        EthereumDataSource::new_from_parts(l1_provider.clone(), beacon, &rollup_config);
+    //
+    // Use the Celo data source, which behaves identically to kona's `EthereumDataSource` pre-fork
+    // and switches to Espresso event-based batch authentication post-fork (see `celo-derive`).
+    let eth_data_source = CeloEthereumDataSource::new_from_parts(
+        l1_provider.clone(),
+        beacon,
+        celo_rollup_config.as_ref(),
+    )
+    .map_err(|e| OracleProviderError::Serde(<serde_json::Error as serde::de::Error>::custom(e)))?;
 
     #[cfg(feature = "eigenda")]
     let da_provider = {

--- a/bin/host/src/single/cfg.rs
+++ b/bin/host/src/single/cfg.rs
@@ -139,7 +139,7 @@ impl CeloSingleChainHost {
     /// Reads the [CeloRollupConfig] from the file system and returns it as a string.
     pub fn read_rollup_config(&self) -> Result<CeloRollupConfig, SingleChainHostError> {
         let rollup_config = self.kona_cfg.read_rollup_config()?;
-        let celo_rollup_config = CeloRollupConfig(rollup_config);
+        let celo_rollup_config = CeloRollupConfig::new(rollup_config);
         Ok(celo_rollup_config)
     }
 

--- a/crates/kona/derive/Cargo.toml
+++ b/crates/kona/derive/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "celo-derive"
+version.workspace = true
+description = "Celo-specific derivation-pipeline extensions (Espresso batch authentication)"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+publish = false
+
+[package.metadata.release]
+release = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# Workspace
+celo-genesis.workspace = true
+
+# Kona
+kona-derive.workspace = true
+kona-protocol.workspace = true
+
+# Alloy
+alloy-primitives.workspace = true
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+
+# Misc
+async-trait.workspace = true
+lru.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+kona-derive = { workspace = true, features = ["test-utils"] }
+kona-genesis.workspace = true
+alloy-rlp.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[features]
+default = []
+std = [
+    "celo-genesis/std",
+    "kona-protocol/std",
+    "alloy-primitives/std",
+    "alloy-consensus/std",
+]

--- a/crates/kona/derive/src/batch_auth.rs
+++ b/crates/kona/derive/src/batch_auth.rs
@@ -1,0 +1,483 @@
+//! Batch Authentication via L1 Event Scanning
+//!
+//! This module implements event-based batch authentication for the Espresso integration.
+//! Instead of relying on an on-chain `BatchInbox` contract to verify batches, the derivation
+//! pipeline scans L1 receipts for `BatchInfoAuthenticated(bytes32 indexed commitment)` events
+//! emitted by the `BatchAuthenticator` contract within a lookback window.
+//!
+//! Whether batches must be authorized by an event is gated by the Espresso hardfork
+//! ([`celo_genesis::CeloEspressoConfig::espresso_time`]). The fork is conceptually an
+//! L2-timestamp hardfork, but the per-L1-block decision made at the data source layer is gated
+//! on the L1 origin time of the block being scanned — mirroring the upstream `ecotoneTime`
+//! precedent.
+//!
+//! - **Pre-fork (or fork unset):** the pipeline runs vanilla OP Stack semantics. A batch is
+//!   authorized iff its sender matches `batcher_address`. The `BatchAuthenticator` event lookback
+//!   is bypassed entirely.
+//! - **Post-fork:** a batch is authorized iff its commitment hash matches a
+//!   `BatchInfoAuthenticated(bytes32 indexed commitment)` event emitted by the configured
+//!   `BatchAuthenticator` contract within the lookback window. Sender-based fallback is rejected.
+//!
+//! The authorization semantics must stay in lockstep with the op-node verifier (the Go batcher
+//! emits the `BatchInfoAuthenticated` events that this module consumes).
+//!
+//! Using event scanning (rather than L1 contract state reads) keeps the derivation pipeline
+//! compatible with the op-program fault proof environment, which can only access L1 block headers,
+//! transactions, receipts, and blobs — not contract state.
+
+use alloc::{collections::BTreeSet, vec::Vec};
+use alloy_consensus::{Receipt, TxEnvelope, TxReceipt, transaction::SignerRecoverable};
+use alloy_primitives::{Address, B256, b256, keccak256};
+use kona_derive::ChainProvider;
+use kona_protocol::BlockInfo;
+use lru::LruCache;
+
+/// The `keccak256("BatchInfoAuthenticated(bytes32)")` event topic.
+///
+/// This is the event emitted by the `BatchAuthenticator` contract when a batch is authenticated.
+/// The first indexed topic is the commitment hash.
+pub const BATCH_INFO_AUTHENTICATED_TOPIC: B256 =
+    b256!("ee0d07d204d979d28885955e59a46f754c4db7378b7df1a95123525aac6e3f80");
+
+/// Configuration for event-based batch authentication.
+///
+/// The presence of this config (as `Some` on a data source) means Espresso event-based batch
+/// authentication is configured for the chain. By bundling the authenticator address together
+/// with the fork time and lookback window, the illegal state "Espresso fork scheduled but no
+/// authenticator address" is unrepresentable: there is no way to have an `espresso_time` without
+/// also having a (non-zero) `authenticator_address`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchAuthConfig {
+    /// The L1 address of the `BatchAuthenticator` contract. Guaranteed non-zero by construction
+    /// (see [`crate::CeloEthereumDataSource::new_from_parts`]).
+    pub authenticator_address: Address,
+    /// Activation timestamp (L2) for the Espresso event-only batch authorization hardfork.
+    ///
+    /// The fork is conceptually an L2-timestamp hardfork, but the per-L1-block decision made at
+    /// the data source layer is gated on the L1 origin time of the block being scanned (see
+    /// [`Self::is_active`]) — mirroring the upstream `ecotoneTime` precedent.
+    pub espresso_time: u64,
+    /// Number of L1 blocks to scan for `BatchInfoAuthenticated` events. Configured per-chain via
+    /// [`celo_genesis::CeloRollupConfig::batch_auth_lookback_window`].
+    pub lookback_window: u64,
+}
+
+impl BatchAuthConfig {
+    /// Returns true when Espresso event-only batch authorization is active at the given L1 origin
+    /// time, i.e. `l1_origin_time >= espresso_time`.
+    ///
+    /// Mirrors [`celo_genesis::CeloRollupConfig::is_espresso_active`] for the case where a
+    /// `BatchAuthenticator` is configured.
+    pub const fn is_active(&self, l1_origin_time: u64) -> bool {
+        l1_origin_time >= self.espresso_time
+    }
+}
+
+/// Computes `keccak256(calldata)`, matching the `BatchAuthenticator` contract's calldata batch
+/// validation path.
+pub fn compute_calldata_batch_hash(data: &[u8]) -> B256 {
+    keccak256(data)
+}
+
+/// Computes `keccak256(concat(blob_hashes))`, matching the `BatchAuthenticator` contract's blob
+/// batch validation path.
+pub fn compute_blob_batch_hash(blob_hashes: &[B256]) -> B256 {
+    let mut concatenated = Vec::with_capacity(32 * blob_hashes.len());
+    for hash in blob_hashes {
+        concatenated.extend_from_slice(hash.as_slice());
+    }
+    keccak256(&concatenated)
+}
+
+/// Extracts all authenticated batch commitment hashes from a single block's receipts.
+///
+/// Scans for `BatchInfoAuthenticated` events emitted by `authenticator_addr` in successful
+/// receipts. Returns the set of commitment hashes found.
+pub fn collect_auth_events_from_receipts(
+    receipts: &[Receipt],
+    authenticator_addr: Address,
+) -> BTreeSet<B256> {
+    let topic0 = BATCH_INFO_AUTHENTICATED_TOPIC;
+    let mut result = BTreeSet::new();
+    for receipt in receipts {
+        if !receipt.status() {
+            continue;
+        }
+        for log in &receipt.logs {
+            if log.address != authenticator_addr {
+                continue;
+            }
+            // `BatchInfoAuthenticated(bytes32 indexed commitment)` has exactly two topics:
+            // the event selector and the single indexed commitment. Require an exact match so a
+            // differently-shaped event that happens to share the selector (e.g. extra indexed
+            // params) is not mistaken for an authorization.
+            if log.topics().len() == 2 && log.topics()[0] == topic0 {
+                result.insert(log.topics()[1]);
+            }
+        }
+    }
+    result
+}
+
+/// Scans L1 receipts in the inclusive range `[block_ref.number - lookback_window,
+/// block_ref.number]` — that is `lookback_window + 1` blocks (the batch's L1 origin block plus
+/// `lookback_window` ancestors) — and returns the set of all batch commitment hashes that were
+/// authenticated via `BatchInfoAuthenticated` events.
+///
+/// This boundary is consensus-critical and must match the op-node batcher/verifier exactly.
+///
+/// This is called once per L1 block by the data source, and the returned set is checked
+/// against each candidate batch transaction. This avoids rescanning the lookback window
+/// for every individual batch transaction.
+///
+/// Results are cached per block hash in the provided LRU cache. For consecutive L1 blocks
+/// the lookback windows overlap by `lookback_window - 1` blocks, so only one new block's
+/// receipts need to be fetched on each call. The cache is keyed by block hash (not number)
+/// so it is naturally reorg-safe.
+pub async fn collect_authenticated_batches<CP: ChainProvider + Send>(
+    provider: &mut CP,
+    block_ref: &BlockInfo,
+    authenticator_addr: Address,
+    lookback_window: u64,
+    cache: &mut BatchAuthCache,
+) -> Result<BTreeSet<B256>, CP::Error> {
+    let mut all_authenticated = BTreeSet::new();
+    let mut current_hash = block_ref.hash;
+    let mut current_number = block_ref.number;
+
+    loop {
+        // Check receipt cache first
+        if let Some(cached) = cache.receipts.get(&current_hash) {
+            all_authenticated.extend(cached.iter());
+        } else {
+            // Cache miss: fetch receipts, extract events, cache the result
+            let receipts = provider.receipts_by_hash(current_hash).await?;
+            let events = collect_auth_events_from_receipts(&receipts, authenticator_addr);
+            all_authenticated.extend(events.iter());
+            cache.receipts.put(current_hash, events);
+        }
+
+        if current_number == 0 || block_ref.number - current_number >= lookback_window {
+            break;
+        }
+
+        // Walk backward using header to get parent hash
+        let parent_hash = if let Some(&cached_parent) = cache.headers.get(&current_hash) {
+            cached_parent
+        } else {
+            let header = provider.header_by_hash(current_hash).await?;
+            cache.headers.put(current_hash, header.parent_hash);
+            header.parent_hash
+        };
+        current_hash = parent_hash;
+        current_number = current_number.saturating_sub(1);
+    }
+
+    Ok(all_authenticated)
+}
+
+/// LRU caches used during the batch authentication lookback window traversal.
+///
+/// Bundles the receipt-event cache and the header (block hash → parent hash) cache.
+/// Both caches are sized slightly larger than the configured lookback window to avoid
+/// thrashing at the boundary.
+#[derive(Debug, Clone)]
+pub struct BatchAuthCache {
+    /// Authenticated batch commitment hashes extracted from receipts, keyed by L1 block hash.
+    pub receipts: LruCache<B256, BTreeSet<B256>>,
+    /// Block parent hashes keyed by block hash
+    pub headers: LruCache<B256, B256>,
+}
+
+impl BatchAuthCache {
+    /// Creates a new [`BatchAuthCache`] with both caches sized to `lookback_window + 2`.
+    pub fn new(lookback_window: u64) -> Self {
+        let cap =
+            lookback_window.try_into().map(|w: usize| w.saturating_add(2)).unwrap_or(usize::MAX);
+        let cap = core::num::NonZeroUsize::new(cap).expect("cache size must be non-zero");
+        Self { receipts: LruCache::new(cap), headers: LruCache::new(cap) }
+    }
+}
+
+/// Checks whether a batch transaction is authorized.
+///
+/// Behaviour is gated by `auth_config` together with `l1_origin_time` (the L1 origin time of the
+/// block being scanned):
+///
+/// - **Pre-fork / vanilla OP Stack** — `auth_config` is `None`, or it is `Some` but the fork is not
+///   yet active at `l1_origin_time` ([`BatchAuthConfig::is_active`] is false): authorized iff the
+///   transaction sender matches `batcher_address`. `authenticated_hashes` is ignored.
+/// - **Post-fork** — `auth_config` is `Some` and active: authorized iff `batch_hash` is present in
+///   `authenticated_hashes`. Sender-based fallback is rejected.
+///
+/// Because the fork time lives inside [`BatchAuthConfig`], the post-fork (event-only) branch is
+/// only reachable when an authenticator is configured — the "fork active but no authenticator"
+/// state is unrepresentable.
+///
+/// If the gap between the authentication transaction and the batch data exceeds the configured
+/// lookback window, it's the batcher's responsibility to detect this and re-submit the
+/// authentication transaction and batch data.
+pub fn is_batch_authorized(
+    tx: &TxEnvelope,
+    batch_hash: B256,
+    auth_config: Option<&BatchAuthConfig>,
+    authenticated_hashes: &BTreeSet<B256>,
+    batcher_address: Address,
+    l1_origin_time: u64,
+) -> bool {
+    if let Some(config) = auth_config &&
+        config.is_active(l1_origin_time)
+    {
+        // Post-fork: event-only authorization. Sender-based fallback is rejected.
+        return authenticated_hashes.contains(&batch_hash);
+    }
+    // Pre-fork (or fork not yet active): vanilla OP Stack sender verification.
+    tx.recover_signer().map(|sender| sender == batcher_address).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{vec, vec::Vec};
+    use alloy_consensus::{Eip658Value, Receipt, Signed, TxLegacy};
+    use alloy_primitives::{Address, Log, LogData, Signature, TxKind, address, b256};
+
+    fn make_auth_receipt(authenticator_addr: Address, commitment: B256) -> Receipt {
+        let topic0 = BATCH_INFO_AUTHENTICATED_TOPIC;
+        let log = Log {
+            address: authenticator_addr,
+            data: LogData::new_unchecked(vec![topic0, commitment], Default::default()),
+        };
+        Receipt { status: Eip658Value::Eip658(true), logs: vec![log], ..Default::default() }
+    }
+
+    fn make_failed_auth_receipt(authenticator_addr: Address, commitment: B256) -> Receipt {
+        let topic0 = BATCH_INFO_AUTHENTICATED_TOPIC;
+        let log = Log {
+            address: authenticator_addr,
+            data: LogData::new_unchecked(vec![topic0, commitment], Default::default()),
+        };
+        Receipt { status: Eip658Value::Eip658(false), logs: vec![log], ..Default::default() }
+    }
+
+    fn test_legacy_tx(to: Address) -> TxEnvelope {
+        let sig = Signature::test_signature();
+        TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy { to: TxKind::Call(to), ..Default::default() },
+            sig,
+            Default::default(),
+        ))
+    }
+
+    #[test]
+    fn test_compute_calldata_batch_hash() {
+        let data = b"hello world";
+        let hash = compute_calldata_batch_hash(data);
+        assert_eq!(hash, keccak256(data));
+    }
+
+    #[test]
+    fn test_compute_blob_batch_hash() {
+        let h1 = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+        let h2 = b256!("0000000000000000000000000000000000000000000000000000000000000002");
+        let hash = compute_blob_batch_hash(&[h1, h2]);
+
+        let mut expected_input = Vec::new();
+        expected_input.extend_from_slice(h1.as_slice());
+        expected_input.extend_from_slice(h2.as_slice());
+        assert_eq!(hash, keccak256(&expected_input));
+    }
+
+    #[test]
+    fn test_collect_auth_events_from_receipts_success() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let commitment = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+
+        let receipt = make_auth_receipt(auth_addr, commitment);
+        let result = collect_auth_events_from_receipts(&[receipt], auth_addr);
+
+        assert!(result.contains(&commitment));
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_collect_auth_events_from_receipts_wrong_address() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let wrong_addr = address!("0000000000000000000000000000000000000001");
+        let commitment = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+
+        let receipt = make_auth_receipt(wrong_addr, commitment);
+        let result = collect_auth_events_from_receipts(&[receipt], auth_addr);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_collect_auth_events_from_receipts_failed_receipt() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let commitment = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+
+        let receipt = make_failed_auth_receipt(auth_addr, commitment);
+        let result = collect_auth_events_from_receipts(&[receipt], auth_addr);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_collect_auth_events_multiple_events() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let c1 = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+        let c2 = b256!("0000000000000000000000000000000000000000000000000000000000000002");
+
+        let r1 = make_auth_receipt(auth_addr, c1);
+        let r2 = make_auth_receipt(auth_addr, c2);
+        let result = collect_auth_events_from_receipts(&[r1, r2], auth_addr);
+
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&c1));
+        assert!(result.contains(&c2));
+    }
+
+    /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
+    fn active_config(authenticator_address: Address) -> BatchAuthConfig {
+        BatchAuthConfig { authenticator_address, espresso_time: 0, lookback_window: 100 }
+    }
+
+    // L1 origin time used as "post-fork" for an `active_config` (espresso_time = 0).
+    const POST_FORK_TIME: u64 = 0;
+
+    #[test]
+    fn test_is_batch_authorized_post_fork_event_path() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let config = active_config(auth_addr);
+        let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+        let mut authenticated = BTreeSet::new();
+        authenticated.insert(batch_hash);
+
+        let tx = test_legacy_tx(Address::ZERO);
+        // Post-fork, event present: authorized regardless of sender.
+        assert!(is_batch_authorized(
+            &tx,
+            batch_hash,
+            Some(&config),
+            &authenticated,
+            Address::ZERO,
+            POST_FORK_TIME,
+        ));
+    }
+
+    #[test]
+    fn test_is_batch_authorized_post_fork_no_event_rejected() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let config = active_config(auth_addr);
+        let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+        let authenticated = BTreeSet::new(); // empty
+
+        let tx = test_legacy_tx(Address::ZERO);
+        // Post-fork, no event: rejected even for an empty hash set.
+        assert!(!is_batch_authorized(
+            &tx,
+            batch_hash,
+            Some(&config),
+            &authenticated,
+            Address::ZERO,
+            POST_FORK_TIME,
+        ));
+    }
+
+    #[test]
+    fn test_is_batch_authorized_post_fork_sender_fallback_rejected() {
+        // Even when sender matches batcher_address, post-fork requires an event.
+        let batch_hash = B256::ZERO;
+        let authenticated = BTreeSet::new();
+
+        let tx = test_legacy_tx(Address::ZERO);
+        let sender = tx.recover_signer().unwrap();
+        // With an active auth_config but no matching event: rejected (no sender fallback).
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let config = active_config(auth_addr);
+        assert!(!is_batch_authorized(
+            &tx,
+            batch_hash,
+            Some(&config),
+            &authenticated,
+            sender,
+            POST_FORK_TIME,
+        ));
+    }
+
+    #[test]
+    fn test_is_batch_authorized_pre_fork_vanilla_sender_path() {
+        let batch_hash = B256::ZERO;
+        let authenticated = BTreeSet::new();
+
+        let tx = test_legacy_tx(Address::ZERO);
+        let sender = tx.recover_signer().unwrap();
+        // No config (Espresso off): sender matches batcher_address => authorized.
+        assert!(is_batch_authorized(&tx, batch_hash, None, &authenticated, sender, 0));
+        // No config: sender mismatch => rejected.
+        assert!(!is_batch_authorized(
+            &tx,
+            batch_hash,
+            None,
+            &authenticated,
+            address!("0000000000000000000000000000000000000001"),
+            0,
+        ));
+    }
+
+    #[test]
+    fn test_is_batch_authorized_not_yet_active_ignores_auth_event() {
+        // Config present but fork not yet active at this L1 time: only the sender check is honored,
+        // even if a matching auth event exists.
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let config = BatchAuthConfig {
+            authenticator_address: auth_addr,
+            espresso_time: 1_000,
+            lookback_window: 100,
+        };
+        let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+        let mut authenticated = BTreeSet::new();
+        authenticated.insert(batch_hash);
+
+        let tx = test_legacy_tx(Address::ZERO);
+        let sender = tx.recover_signer().unwrap();
+        let wrong_addr = address!("0000000000000000000000000000000000000001");
+        let pre_fork_time = 999; // < espresso_time
+
+        // Sender mismatch: even with an event present, we reject (event path is gated off).
+        assert!(!is_batch_authorized(
+            &tx,
+            batch_hash,
+            Some(&config),
+            &authenticated,
+            wrong_addr,
+            pre_fork_time,
+        ));
+        // Sender match: authorized via the pre-fork path.
+        assert!(is_batch_authorized(
+            &tx,
+            batch_hash,
+            Some(&config),
+            &authenticated,
+            sender,
+            pre_fork_time,
+        ));
+    }
+
+    #[test]
+    fn test_batch_info_authenticated_topic_is_correct() {
+        assert_eq!(BATCH_INFO_AUTHENTICATED_TOPIC, keccak256("BatchInfoAuthenticated(bytes32)"));
+    }
+
+    #[test]
+    fn test_new_batch_auth_cache() {
+        let lookback = 100u64;
+        let cache = BatchAuthCache::new(lookback);
+        let expected_cap = (lookback as usize) + 2;
+        assert_eq!(cache.receipts.len(), 0);
+        assert_eq!(cache.receipts.cap().get(), expected_cap);
+        assert_eq!(cache.headers.len(), 0);
+        assert_eq!(cache.headers.cap().get(), expected_cap);
+    }
+}

--- a/crates/kona/derive/src/batch_auth.rs
+++ b/crates/kona/derive/src/batch_auth.rs
@@ -2,8 +2,8 @@
 //!
 //! This module implements event-based batch authentication for the Espresso integration.
 //! Instead of relying on an on-chain `BatchInbox` contract to verify batches, the derivation
-//! pipeline scans L1 receipts for `BatchInfoAuthenticated(bytes32 indexed commitment)` events
-//! emitted by the `BatchAuthenticator` contract within a lookback window.
+//! pipeline scans L1 receipts for `BatchInfoAuthenticated(bytes32 commitment, address indexed
+//! caller)` events emitted by the `BatchAuthenticator` contract within a lookback window.
 //!
 //! Whether batches must be authorized by an event is gated by the Espresso hardfork
 //! ([`celo_genesis::CeloEspressoConfig::espresso_time`]). The fork is conceptually an
@@ -14,9 +14,13 @@
 //! - **Pre-fork (or fork unset):** the pipeline runs vanilla OP Stack semantics. A batch is
 //!   authorized iff its sender matches `batcher_address`. The `BatchAuthenticator` event lookback
 //!   is bypassed entirely.
-//! - **Post-fork:** a batch is authorized iff its commitment hash matches a
-//!   `BatchInfoAuthenticated(bytes32 indexed commitment)` event emitted by the configured
-//!   `BatchAuthenticator` contract within the lookback window. Sender-based fallback is rejected.
+//! - **Post-fork:** a batch is authorized iff its commitment hash was authenticated by a
+//!   `BatchInfoAuthenticated(bytes32 commitment, address indexed caller)` event emitted by the
+//!   configured `BatchAuthenticator` contract within the lookback window AND the batch
+//!   transaction's recovered L1 sender equals the `caller` that emitted that event. This
+//!   caller-binding prevents one batcher from replaying a batch authenticated by another. On
+//!   duplicate authentication of the same commitment within the lookback window, the newest event's
+//!   caller wins.
 //!
 //! The authorization semantics must stay in lockstep with the op-node verifier (the Go batcher
 //! emits the `BatchInfoAuthenticated` events that this module consumes).
@@ -25,7 +29,7 @@
 //! compatible with the op-program fault proof environment, which can only access L1 block headers,
 //! transactions, receipts, and blobs — not contract state.
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_consensus::{Receipt, TxEnvelope, TxReceipt, transaction::SignerRecoverable};
 use alloy_primitives::{Address, B256, b256, keccak256};
 use celo_genesis::BATCH_AUTH_LOOKBACK_WINDOW;
@@ -33,12 +37,13 @@ use kona_derive::ChainProvider;
 use kona_protocol::BlockInfo;
 use lru::LruCache;
 
-/// The `keccak256("BatchInfoAuthenticated(bytes32)")` event topic.
+/// The `keccak256("BatchInfoAuthenticated(bytes32,address)")` event topic.
 ///
 /// This is the event emitted by the `BatchAuthenticator` contract when a batch is authenticated.
-/// The first indexed topic is the commitment hash.
+/// The commitment hash is the first (unindexed) data argument, read from `Data[:32]`; the
+/// authenticating `caller` is the single indexed topic (`Topics[1]`).
 pub const BATCH_INFO_AUTHENTICATED_TOPIC: B256 =
-    b256!("ee0d07d204d979d28885955e59a46f754c4db7378b7df1a95123525aac6e3f80");
+    b256!("731978a77d438b0ea35a9034fb28d9cf9372e1649f18c213110adcfab65c5c5c");
 
 /// Configuration for event-based batch authentication.
 ///
@@ -84,16 +89,18 @@ pub fn compute_blob_batch_hash(blob_hashes: &[B256]) -> B256 {
     keccak256(&concatenated)
 }
 
-/// Extracts all authenticated batch commitment hashes from a single block's receipts.
+/// Extracts all authenticated batch commitments from a single block's receipts.
 ///
-/// Scans for `BatchInfoAuthenticated` events emitted by `authenticator_addr` in successful
-/// receipts. Returns the set of commitment hashes found.
+/// Scans for `BatchInfoAuthenticated(bytes32 commitment, address indexed caller)` events emitted
+/// by `authenticator_addr` in successful receipts. Returns a map of commitment hash to the
+/// `caller` address that authenticated it. Within a single block, a later log for the same
+/// commitment overwrites an earlier one.
 pub fn collect_auth_events_from_receipts(
     receipts: &[Receipt],
     authenticator_addr: Address,
-) -> BTreeSet<B256> {
+) -> BTreeMap<B256, Address> {
     let topic0 = BATCH_INFO_AUTHENTICATED_TOPIC;
-    let mut result = BTreeSet::new();
+    let mut result = BTreeMap::new();
     for receipt in receipts {
         if !receipt.status() {
             continue;
@@ -102,12 +109,14 @@ pub fn collect_auth_events_from_receipts(
             if log.address != authenticator_addr {
                 continue;
             }
-            // `BatchInfoAuthenticated(bytes32 indexed commitment)` has exactly two topics:
-            // the event selector and the single indexed commitment. Require an exact match so a
-            // differently-shaped event that happens to share the selector (e.g. extra indexed
-            // params) is not mistaken for an authorization.
-            if log.topics().len() == 2 && log.topics()[0] == topic0 {
-                result.insert(log.topics()[1]);
+            // `BatchInfoAuthenticated(bytes32 commitment, address indexed caller)` carries the
+            // commitment as the first (unindexed) data word and the `caller` as the single
+            // indexed topic. Require the selector to match and at least two topics (selector +
+            // caller) plus at least 32 data bytes for the commitment.
+            if log.topics().len() >= 2 && log.topics()[0] == topic0 && log.data.data.len() >= 32 {
+                let commitment = B256::from_slice(&log.data.data[..32]);
+                let caller = Address::from_word(log.topics()[1]);
+                result.insert(commitment, caller);
             }
         }
     }
@@ -116,12 +125,17 @@ pub fn collect_auth_events_from_receipts(
 
 /// Scans L1 receipts in the inclusive range `[block_ref.number - BATCH_AUTH_LOOKBACK_WINDOW,
 /// block_ref.number]` — that is `BATCH_AUTH_LOOKBACK_WINDOW + 1` blocks (the batch's L1 origin
-/// block plus [`BATCH_AUTH_LOOKBACK_WINDOW`] ancestors) — and returns the set of all batch
-/// commitment hashes that were authenticated via `BatchInfoAuthenticated` events.
+/// block plus [`BATCH_AUTH_LOOKBACK_WINDOW`] ancestors) — and returns a map of all batch
+/// commitment hashes that were authenticated via `BatchInfoAuthenticated` events to the `caller`
+/// that authenticated them.
 ///
 /// This boundary is consensus-critical and must match the op-node batcher/verifier exactly.
 ///
-/// This is called once per L1 block by the data source, and the returned set is checked
+/// Traversal walks newest block first. When the same commitment is authenticated more than once
+/// within the lookback window, the newest event's caller wins (a commitment is only inserted if
+/// it is not already present, and the already-present entry came from a newer block).
+///
+/// This is called once per L1 block by the data source, and the returned map is checked
 /// against each candidate batch transaction. This avoids rescanning the lookback window
 /// for every individual batch transaction.
 ///
@@ -134,20 +148,26 @@ pub async fn collect_authenticated_batches<CP: ChainProvider + Send>(
     block_ref: &BlockInfo,
     authenticator_addr: Address,
     cache: &mut BatchAuthCache,
-) -> Result<BTreeSet<B256>, CP::Error> {
-    let mut all_authenticated = BTreeSet::new();
+) -> Result<BTreeMap<B256, Address>, CP::Error> {
+    let mut all_authenticated: BTreeMap<B256, Address> = BTreeMap::new();
     let mut current_hash = block_ref.hash;
     let mut current_number = block_ref.number;
 
     loop {
         // Check receipt cache first
         if let Some(cached) = cache.receipts.get(&current_hash) {
-            all_authenticated.extend(cached.iter());
+            // Newest-wins merge: traversal walks newest -> oldest, so a commitment already in the
+            // accumulator came from a newer block and must not be overwritten by this older one.
+            for (commitment, caller) in cached {
+                all_authenticated.entry(*commitment).or_insert(*caller);
+            }
         } else {
             // Cache miss: fetch receipts, extract events, cache the result
             let receipts = provider.receipts_by_hash(current_hash).await?;
             let events = collect_auth_events_from_receipts(&receipts, authenticator_addr);
-            all_authenticated.extend(events.iter());
+            for (commitment, caller) in &events {
+                all_authenticated.entry(*commitment).or_insert(*caller);
+            }
             cache.receipts.put(current_hash, events);
         }
 
@@ -177,8 +197,9 @@ pub async fn collect_authenticated_batches<CP: ChainProvider + Send>(
 /// boundary.
 #[derive(Debug, Clone)]
 pub struct BatchAuthCache {
-    /// Authenticated batch commitment hashes extracted from receipts, keyed by L1 block hash.
-    pub receipts: LruCache<B256, BTreeSet<B256>>,
+    /// Authenticated batch commitments (commitment hash → authenticating `caller`) extracted from
+    /// receipts, keyed by L1 block hash.
+    pub receipts: LruCache<B256, BTreeMap<B256, Address>>,
     /// Block parent hashes keyed by block hash
     pub headers: LruCache<B256, B256>,
 }
@@ -210,9 +231,11 @@ impl BatchAuthCache {
 ///   yet active at `l1_origin_time` ([`BatchAuthConfig::is_active`] is false): authorized iff the
 ///   transaction sender matches `batcher_address`. `authenticated_hashes` is ignored.
 /// - **Post-fork** — `auth_config` is `Some` and active: authorized iff `batch_hash` is present in
-///   `authenticated_hashes`. Sender-based fallback is rejected.
+///   `authenticated_hashes` AND the transaction's recovered L1 sender equals the `caller` that
+///   authenticated that commitment. This caller-binding prevents one batcher from replaying a batch
+///   authenticated by another.
 ///
-/// Because the fork time lives inside [`BatchAuthConfig`], the post-fork (event-only) branch is
+/// Because the fork time lives inside [`BatchAuthConfig`], the post-fork (caller-bound) branch is
 /// only reachable when an authenticator is configured — the "fork active but no authenticator"
 /// state is unrepresentable.
 ///
@@ -223,15 +246,20 @@ pub fn is_batch_authorized(
     tx: &TxEnvelope,
     batch_hash: B256,
     auth_config: Option<&BatchAuthConfig>,
-    authenticated_hashes: &BTreeSet<B256>,
+    authenticated_hashes: &BTreeMap<B256, Address>,
     batcher_address: Address,
     l1_origin_time: u64,
 ) -> bool {
     if let Some(config) = auth_config &&
         config.is_active(l1_origin_time)
     {
-        // Post-fork: event-only authorization. Sender-based fallback is rejected.
-        return authenticated_hashes.contains(&batch_hash);
+        // Post-fork: the commitment must be authenticated AND the recovered batch tx sender must
+        // equal the `caller` that emitted the authenticating event. Sender-based fallback is
+        // rejected.
+        let Some(&caller) = authenticated_hashes.get(&batch_hash) else {
+            return false;
+        };
+        return tx.recover_signer().map(|sender| sender == caller).unwrap_or(false);
     }
     // Pre-fork (or fork not yet active): vanilla OP Stack sender verification.
     tx.recover_signer().map(|sender| sender == batcher_address).unwrap_or(false)
@@ -244,20 +272,34 @@ mod tests {
     use alloy_consensus::{Eip658Value, Receipt, Signed, TxLegacy};
     use alloy_primitives::{Address, Log, LogData, Signature, TxKind, address, b256};
 
-    fn make_auth_receipt(authenticator_addr: Address, commitment: B256) -> Receipt {
+    fn make_auth_receipt(
+        authenticator_addr: Address,
+        commitment: B256,
+        caller: Address,
+    ) -> Receipt {
         let topic0 = BATCH_INFO_AUTHENTICATED_TOPIC;
         let log = Log {
             address: authenticator_addr,
-            data: LogData::new_unchecked(vec![topic0, commitment], Default::default()),
+            data: LogData::new_unchecked(
+                vec![topic0, caller.into_word()],
+                commitment.as_slice().to_vec().into(),
+            ),
         };
         Receipt { status: Eip658Value::Eip658(true), logs: vec![log], ..Default::default() }
     }
 
-    fn make_failed_auth_receipt(authenticator_addr: Address, commitment: B256) -> Receipt {
+    fn make_failed_auth_receipt(
+        authenticator_addr: Address,
+        commitment: B256,
+        caller: Address,
+    ) -> Receipt {
         let topic0 = BATCH_INFO_AUTHENTICATED_TOPIC;
         let log = Log {
             address: authenticator_addr,
-            data: LogData::new_unchecked(vec![topic0, commitment], Default::default()),
+            data: LogData::new_unchecked(
+                vec![topic0, caller.into_word()],
+                commitment.as_slice().to_vec().into(),
+            ),
         };
         Receipt { status: Eip658Value::Eip658(false), logs: vec![log], ..Default::default() }
     }
@@ -294,11 +336,12 @@ mod tests {
     fn test_collect_auth_events_from_receipts_success() {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let commitment = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+        let caller = address!("00000000000000000000000000000000000000aa");
 
-        let receipt = make_auth_receipt(auth_addr, commitment);
+        let receipt = make_auth_receipt(auth_addr, commitment, caller);
         let result = collect_auth_events_from_receipts(&[receipt], auth_addr);
 
-        assert!(result.contains(&commitment));
+        assert_eq!(result.get(&commitment), Some(&caller));
         assert_eq!(result.len(), 1);
     }
 
@@ -307,8 +350,9 @@ mod tests {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let wrong_addr = address!("0000000000000000000000000000000000000001");
         let commitment = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+        let caller = address!("00000000000000000000000000000000000000aa");
 
-        let receipt = make_auth_receipt(wrong_addr, commitment);
+        let receipt = make_auth_receipt(wrong_addr, commitment, caller);
         let result = collect_auth_events_from_receipts(&[receipt], auth_addr);
 
         assert!(result.is_empty());
@@ -318,8 +362,9 @@ mod tests {
     fn test_collect_auth_events_from_receipts_failed_receipt() {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let commitment = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+        let caller = address!("00000000000000000000000000000000000000aa");
 
-        let receipt = make_failed_auth_receipt(auth_addr, commitment);
+        let receipt = make_failed_auth_receipt(auth_addr, commitment, caller);
         let result = collect_auth_events_from_receipts(&[receipt], auth_addr);
 
         assert!(result.is_empty());
@@ -330,14 +375,16 @@ mod tests {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let c1 = b256!("0000000000000000000000000000000000000000000000000000000000000001");
         let c2 = b256!("0000000000000000000000000000000000000000000000000000000000000002");
+        let caller1 = address!("00000000000000000000000000000000000000aa");
+        let caller2 = address!("00000000000000000000000000000000000000bb");
 
-        let r1 = make_auth_receipt(auth_addr, c1);
-        let r2 = make_auth_receipt(auth_addr, c2);
+        let r1 = make_auth_receipt(auth_addr, c1, caller1);
+        let r2 = make_auth_receipt(auth_addr, c2, caller2);
         let result = collect_auth_events_from_receipts(&[r1, r2], auth_addr);
 
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&c1));
-        assert!(result.contains(&c2));
+        assert_eq!(result.get(&c1), Some(&caller1));
+        assert_eq!(result.get(&c2), Some(&caller2));
     }
 
     /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
@@ -349,16 +396,42 @@ mod tests {
     const POST_FORK_TIME: u64 = 0;
 
     #[test]
-    fn test_is_batch_authorized_post_fork_event_path() {
+    fn test_is_batch_authorized_post_fork_matching_caller_accepted() {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let config = active_config(auth_addr);
         let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
-        let mut authenticated = BTreeSet::new();
-        authenticated.insert(batch_hash);
 
         let tx = test_legacy_tx(Address::ZERO);
-        // Post-fork, event present: authorized regardless of sender.
+        let sender = tx.recover_signer().unwrap();
+        let mut authenticated = BTreeMap::new();
+        // The commitment was authenticated by the tx's own sender.
+        authenticated.insert(batch_hash, sender);
+
+        // Post-fork, commitment authenticated and tx sender == authenticating caller: authorized.
         assert!(is_batch_authorized(
+            &tx,
+            batch_hash,
+            Some(&config),
+            &authenticated,
+            Address::ZERO,
+            POST_FORK_TIME,
+        ));
+    }
+
+    #[test]
+    fn test_is_batch_authorized_post_fork_caller_mismatch_rejected() {
+        let auth_addr = address!("1234567890123456789012345678901234567890");
+        let config = active_config(auth_addr);
+        let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
+
+        let tx = test_legacy_tx(Address::ZERO);
+        let other_caller = address!("00000000000000000000000000000000000000aa");
+        let mut authenticated = BTreeMap::new();
+        // The commitment is authenticated, but by a different caller than the tx sender.
+        authenticated.insert(batch_hash, other_caller);
+
+        // Post-fork, commitment authenticated but tx sender != authenticating caller: rejected.
+        assert!(!is_batch_authorized(
             &tx,
             batch_hash,
             Some(&config),
@@ -373,10 +446,10 @@ mod tests {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let config = active_config(auth_addr);
         let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
-        let authenticated = BTreeSet::new(); // empty
+        let authenticated = BTreeMap::new(); // empty
 
         let tx = test_legacy_tx(Address::ZERO);
-        // Post-fork, no event: rejected even for an empty hash set.
+        // Post-fork, commitment absent: rejected even for an empty map.
         assert!(!is_batch_authorized(
             &tx,
             batch_hash,
@@ -389,9 +462,10 @@ mod tests {
 
     #[test]
     fn test_is_batch_authorized_post_fork_sender_fallback_rejected() {
-        // Even when sender matches batcher_address, post-fork requires an event.
+        // Even when sender matches batcher_address, post-fork requires an authenticating event
+        // for the commitment.
         let batch_hash = B256::ZERO;
-        let authenticated = BTreeSet::new();
+        let authenticated = BTreeMap::new();
 
         let tx = test_legacy_tx(Address::ZERO);
         let sender = tx.recover_signer().unwrap();
@@ -411,7 +485,7 @@ mod tests {
     #[test]
     fn test_is_batch_authorized_pre_fork_vanilla_sender_path() {
         let batch_hash = B256::ZERO;
-        let authenticated = BTreeSet::new();
+        let authenticated = BTreeMap::new();
 
         let tx = test_legacy_tx(Address::ZERO);
         let sender = tx.recover_signer().unwrap();
@@ -435,11 +509,11 @@ mod tests {
         let auth_addr = address!("1234567890123456789012345678901234567890");
         let config = BatchAuthConfig { authenticator_address: auth_addr, espresso_time: 1_000 };
         let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
-        let mut authenticated = BTreeSet::new();
-        authenticated.insert(batch_hash);
+        let mut authenticated = BTreeMap::new();
 
         let tx = test_legacy_tx(Address::ZERO);
         let sender = tx.recover_signer().unwrap();
+        authenticated.insert(batch_hash, sender);
         let wrong_addr = address!("0000000000000000000000000000000000000001");
         let pre_fork_time = 999; // < espresso_time
 
@@ -465,7 +539,10 @@ mod tests {
 
     #[test]
     fn test_batch_info_authenticated_topic_is_correct() {
-        assert_eq!(BATCH_INFO_AUTHENTICATED_TOPIC, keccak256("BatchInfoAuthenticated(bytes32)"));
+        assert_eq!(
+            BATCH_INFO_AUTHENTICATED_TOPIC,
+            keccak256("BatchInfoAuthenticated(bytes32,address)")
+        );
     }
 
     #[test]

--- a/crates/kona/derive/src/batch_auth.rs
+++ b/crates/kona/derive/src/batch_auth.rs
@@ -28,6 +28,7 @@
 use alloc::{collections::BTreeSet, vec::Vec};
 use alloy_consensus::{Receipt, TxEnvelope, TxReceipt, transaction::SignerRecoverable};
 use alloy_primitives::{Address, B256, b256, keccak256};
+use celo_genesis::BATCH_AUTH_LOOKBACK_WINDOW;
 use kona_derive::ChainProvider;
 use kona_protocol::BlockInfo;
 use lru::LruCache;
@@ -41,11 +42,8 @@ pub const BATCH_INFO_AUTHENTICATED_TOPIC: B256 =
 
 /// Configuration for event-based batch authentication.
 ///
-/// The presence of this config (as `Some` on a data source) means Espresso event-based batch
-/// authentication is configured for the chain. By bundling the authenticator address together
-/// with the fork time and lookback window, the illegal state "Espresso fork scheduled but no
-/// authenticator address" is unrepresentable: there is no way to have an `espresso_time` without
-/// also having a (non-zero) `authenticator_address`.
+/// The lookback window is not part of this config: it is the hardcoded consensus constant
+/// [`celo_genesis::BATCH_AUTH_LOOKBACK_WINDOW`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BatchAuthConfig {
     /// The L1 address of the `BatchAuthenticator` contract. Guaranteed non-zero by construction
@@ -57,9 +55,6 @@ pub struct BatchAuthConfig {
     /// the data source layer is gated on the L1 origin time of the block being scanned (see
     /// [`Self::is_active`]) — mirroring the upstream `ecotoneTime` precedent.
     pub espresso_time: u64,
-    /// Number of L1 blocks to scan for `BatchInfoAuthenticated` events. Configured per-chain via
-    /// [`celo_genesis::CeloRollupConfig::batch_auth_lookback_window`].
-    pub lookback_window: u64,
 }
 
 impl BatchAuthConfig {
@@ -119,10 +114,10 @@ pub fn collect_auth_events_from_receipts(
     result
 }
 
-/// Scans L1 receipts in the inclusive range `[block_ref.number - lookback_window,
-/// block_ref.number]` — that is `lookback_window + 1` blocks (the batch's L1 origin block plus
-/// `lookback_window` ancestors) — and returns the set of all batch commitment hashes that were
-/// authenticated via `BatchInfoAuthenticated` events.
+/// Scans L1 receipts in the inclusive range `[block_ref.number - BATCH_AUTH_LOOKBACK_WINDOW,
+/// block_ref.number]` — that is `BATCH_AUTH_LOOKBACK_WINDOW + 1` blocks (the batch's L1 origin
+/// block plus [`BATCH_AUTH_LOOKBACK_WINDOW`] ancestors) — and returns the set of all batch
+/// commitment hashes that were authenticated via `BatchInfoAuthenticated` events.
 ///
 /// This boundary is consensus-critical and must match the op-node batcher/verifier exactly.
 ///
@@ -131,14 +126,13 @@ pub fn collect_auth_events_from_receipts(
 /// for every individual batch transaction.
 ///
 /// Results are cached per block hash in the provided LRU cache. For consecutive L1 blocks
-/// the lookback windows overlap by `lookback_window - 1` blocks, so only one new block's
-/// receipts need to be fetched on each call. The cache is keyed by block hash (not number)
-/// so it is naturally reorg-safe.
+/// the lookback windows overlap by `BATCH_AUTH_LOOKBACK_WINDOW - 1` blocks, so only one new
+/// block's receipts need to be fetched on each call. The cache is keyed by block hash (not
+/// number) so it is naturally reorg-safe.
 pub async fn collect_authenticated_batches<CP: ChainProvider + Send>(
     provider: &mut CP,
     block_ref: &BlockInfo,
     authenticator_addr: Address,
-    lookback_window: u64,
     cache: &mut BatchAuthCache,
 ) -> Result<BTreeSet<B256>, CP::Error> {
     let mut all_authenticated = BTreeSet::new();
@@ -157,7 +151,7 @@ pub async fn collect_authenticated_batches<CP: ChainProvider + Send>(
             cache.receipts.put(current_hash, events);
         }
 
-        if current_number == 0 || block_ref.number - current_number >= lookback_window {
+        if current_number == 0 || block_ref.number - current_number >= BATCH_AUTH_LOOKBACK_WINDOW {
             break;
         }
 
@@ -179,8 +173,8 @@ pub async fn collect_authenticated_batches<CP: ChainProvider + Send>(
 /// LRU caches used during the batch authentication lookback window traversal.
 ///
 /// Bundles the receipt-event cache and the header (block hash → parent hash) cache.
-/// Both caches are sized slightly larger than the configured lookback window to avoid
-/// thrashing at the boundary.
+/// Both caches are sized slightly larger than the lookback window to avoid thrashing at the
+/// boundary.
 #[derive(Debug, Clone)]
 pub struct BatchAuthCache {
     /// Authenticated batch commitment hashes extracted from receipts, keyed by L1 block hash.
@@ -189,11 +183,19 @@ pub struct BatchAuthCache {
     pub headers: LruCache<B256, B256>,
 }
 
+impl Default for BatchAuthCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BatchAuthCache {
-    /// Creates a new [`BatchAuthCache`] with both caches sized to `lookback_window + 2`.
-    pub fn new(lookback_window: u64) -> Self {
-        let cap =
-            lookback_window.try_into().map(|w: usize| w.saturating_add(2)).unwrap_or(usize::MAX);
+    /// Creates a new [`BatchAuthCache`] with both caches sized to
+    /// [`BATCH_AUTH_LOOKBACK_WINDOW`] `+ 2`.
+    pub fn new() -> Self {
+        let cap = usize::try_from(BATCH_AUTH_LOOKBACK_WINDOW)
+            .map(|w| w.saturating_add(2))
+            .unwrap_or(usize::MAX);
         let cap = core::num::NonZeroUsize::new(cap).expect("cache size must be non-zero");
         Self { receipts: LruCache::new(cap), headers: LruCache::new(cap) }
     }
@@ -340,7 +342,7 @@ mod tests {
 
     /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
     fn active_config(authenticator_address: Address) -> BatchAuthConfig {
-        BatchAuthConfig { authenticator_address, espresso_time: 0, lookback_window: 100 }
+        BatchAuthConfig { authenticator_address, espresso_time: 0 }
     }
 
     // L1 origin time used as "post-fork" for an `active_config` (espresso_time = 0).
@@ -431,11 +433,7 @@ mod tests {
         // Config present but fork not yet active at this L1 time: only the sender check is honored,
         // even if a matching auth event exists.
         let auth_addr = address!("1234567890123456789012345678901234567890");
-        let config = BatchAuthConfig {
-            authenticator_address: auth_addr,
-            espresso_time: 1_000,
-            lookback_window: 100,
-        };
+        let config = BatchAuthConfig { authenticator_address: auth_addr, espresso_time: 1_000 };
         let batch_hash = b256!("abcdef0000000000000000000000000000000000000000000000000000000000");
         let mut authenticated = BTreeSet::new();
         authenticated.insert(batch_hash);
@@ -472,9 +470,8 @@ mod tests {
 
     #[test]
     fn test_new_batch_auth_cache() {
-        let lookback = 100u64;
-        let cache = BatchAuthCache::new(lookback);
-        let expected_cap = (lookback as usize) + 2;
+        let cache = BatchAuthCache::new();
+        let expected_cap = (BATCH_AUTH_LOOKBACK_WINDOW as usize) + 2;
         assert_eq!(cache.receipts.len(), 0);
         assert_eq!(cache.receipts.cap().get(), expected_cap);
         assert_eq!(cache.headers.len(), 0);

--- a/crates/kona/derive/src/blob_data.rs
+++ b/crates/kona/derive/src/blob_data.rs
@@ -1,0 +1,297 @@
+//! Contains the [`CeloBlobData`] struct.
+//!
+//! This is a verbatim duplicate of kona's internal `BlobData` (whose fields and decode/fill
+//! helpers are `pub(crate)` and therefore not reachable from celo-kona). celo-kona wraps upstream
+//! kona instead of patching it, so the blob-decoding logic is duplicated here to support the
+//! Espresso event-authenticated blob path in [`crate::CeloBlobSource`].
+
+use alloc::{boxed::Box, vec};
+use alloy_eips::eip4844::{BYTES_PER_BLOB, Blob, VERSIONED_HASH_VERSION_KZG};
+use alloy_primitives::Bytes;
+use kona_derive::{BlobDecodingError, BlobProviderError};
+
+/// The blob encoding version
+pub(crate) const BLOB_ENCODING_VERSION: u8 = 0;
+
+/// Maximum blob data size
+pub(crate) const BLOB_MAX_DATA_SIZE: usize = (4 * 31 + 3) * 1024 - 4; // 130044
+
+/// Blob Encoding/Decoding Rounds
+pub(crate) const BLOB_ENCODING_ROUNDS: usize = 1024;
+
+/// The Blob Data
+#[derive(Default, Clone, Debug)]
+pub struct CeloBlobData {
+    /// The blob data
+    pub(crate) data: Option<Bytes>,
+    /// The calldata
+    pub(crate) calldata: Option<Bytes>,
+}
+
+impl CeloBlobData {
+    /// Decodes the blob into raw byte data.
+    /// Returns a [`BlobDecodingError`] if the blob is invalid.
+    pub(crate) fn decode(&self) -> Result<Bytes, BlobDecodingError> {
+        let data = self.data.as_ref().ok_or(BlobDecodingError::MissingData)?;
+
+        // Validate the blob encoding version
+        if data[VERSIONED_HASH_VERSION_KZG as usize] != BLOB_ENCODING_VERSION {
+            return Err(BlobDecodingError::InvalidEncodingVersion);
+        }
+
+        // Decode the 3 byte big endian length value into a 4 byte integer
+        let length = u32::from_be_bytes([0, data[2], data[3], data[4]]) as usize;
+
+        // Validate the length
+        if length > BLOB_MAX_DATA_SIZE {
+            return Err(BlobDecodingError::InvalidLength);
+        }
+
+        // Round 0 copies the remaining 27 bytes of the first field element
+        let mut output = vec![0u8; BLOB_MAX_DATA_SIZE];
+        output[0..27].copy_from_slice(&data[5..32]);
+
+        // Process the remaining 3 field elements to complete round 0
+        let mut output_pos = 28;
+        let mut input_pos = 32;
+        let mut encoded_byte = [0u8; 4];
+        encoded_byte[0] = data[0];
+
+        for b in encoded_byte.iter_mut().skip(1) {
+            let (enc, opos, ipos) =
+                self.decode_field_element(output_pos, input_pos, &mut output)?;
+            *b = enc;
+            output_pos = opos;
+            input_pos = ipos;
+        }
+
+        // Reassemble the 4 by 6 bit encoded chunks into 3 bytes of output
+        output_pos = self.reassemble_bytes(output_pos, &encoded_byte, &mut output);
+
+        // In each remaining round, decode 4 field elements (128 bytes) of the
+        // input into 127 bytes of output
+        for _ in 1..BLOB_ENCODING_ROUNDS {
+            // Break early if the output position is greater than the length
+            if output_pos >= length {
+                break;
+            }
+
+            for d in &mut encoded_byte {
+                let (enc, opos, ipos) =
+                    self.decode_field_element(output_pos, input_pos, &mut output)?;
+                *d = enc;
+                output_pos = opos;
+                input_pos = ipos;
+            }
+            output_pos = self.reassemble_bytes(output_pos, &encoded_byte, &mut output);
+        }
+
+        // Validate the remaining bytes
+        for o in output.iter().skip(length) {
+            if *o != 0u8 {
+                return Err(BlobDecodingError::InvalidFieldElement);
+            }
+        }
+
+        // Validate the remaining bytes
+        output.truncate(length);
+        for i in input_pos..BYTES_PER_BLOB {
+            if data[i] != 0 {
+                return Err(BlobDecodingError::InvalidFieldElement);
+            }
+        }
+
+        Ok(Bytes::from(output))
+    }
+
+    /// Decodes the next input field element by writing its lower 31 bytes into its
+    /// appropriate place in the output and checking the high order byte is valid.
+    /// Returns a [`BlobDecodingError`] if a field element is seen with either of its
+    /// two high order bits set.
+    pub(crate) fn decode_field_element(
+        &self,
+        output_pos: usize,
+        input_pos: usize,
+        output: &mut [u8],
+    ) -> Result<(u8, usize, usize), BlobDecodingError> {
+        let Some(data) = self.data.as_ref() else {
+            return Err(BlobDecodingError::MissingData);
+        };
+
+        // two highest order bits of the first byte of each field element should always be 0
+        if data[input_pos] & 0b1100_0000 != 0 {
+            return Err(BlobDecodingError::InvalidFieldElement);
+        }
+        output[output_pos..output_pos + 31].copy_from_slice(&data[input_pos + 1..input_pos + 32]);
+        Ok((data[input_pos], output_pos + 32, input_pos + 32))
+    }
+
+    /// Reassemble 4 by 6 bit encoded chunks into 3 bytes of output and place them in their
+    /// appropriate output positions.
+    pub(crate) fn reassemble_bytes(
+        &self,
+        mut output_pos: usize,
+        encoded_byte: &[u8],
+        output: &mut [u8],
+    ) -> usize {
+        output_pos -= 1;
+        let x = (encoded_byte[0] & 0b0011_1111) | ((encoded_byte[1] & 0b0011_0000) << 2);
+        let y = (encoded_byte[1] & 0b0000_1111) | ((encoded_byte[3] & 0b0000_1111) << 4);
+        let z = (encoded_byte[2] & 0b0011_1111) | ((encoded_byte[3] & 0b0011_0000) << 2);
+        output[output_pos - 32] = z;
+        output[output_pos - (32 * 2)] = y;
+        output[output_pos - (32 * 3)] = x;
+        output_pos
+    }
+
+    /// Fills in the pointers to the fetched blob bodies.
+    /// There should be exactly one placeholder blobOrCalldata
+    /// element for each blob, otherwise an error is returned.
+    pub(crate) fn fill(
+        &mut self,
+        blobs: &[Box<Blob>],
+        index: usize,
+    ) -> Result<bool, BlobProviderError> {
+        // Do not fill if there is calldata here
+        if self.calldata.is_some() {
+            return Ok(false);
+        }
+
+        if index >= blobs.len() {
+            return Err(BlobProviderError::NotEnoughBlobs { expected: index, actual: blobs.len() });
+        }
+
+        if blobs[index].is_empty() {
+            return Err(BlobDecodingError::MissingData.into());
+        }
+
+        self.data = Some(Bytes::from(*blobs[index]));
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reassemble_bytes() {
+        let blob_data = CeloBlobData::default();
+        let mut output = vec![0u8; 128];
+        let encoded_byte = [0x00, 0x00, 0x00, 0x00];
+        let output_pos = blob_data.reassemble_bytes(127, &encoded_byte, &mut output);
+        assert_eq!(output_pos, 126);
+        assert_eq!(output, vec![0u8; 128]);
+    }
+
+    #[test]
+    fn test_cannot_fill_empty_calldata() {
+        let mut blob_data = CeloBlobData { calldata: Some(Bytes::new()), ..Default::default() };
+        let blobs = vec![Box::new(Blob::with_last_byte(1u8))];
+        assert_eq!(blob_data.fill(&blobs, 0), Ok(false));
+    }
+
+    #[test]
+    fn test_fill_oob_index() {
+        let mut blob_data = CeloBlobData::default();
+        let blobs = vec![Box::new(Blob::with_last_byte(1u8))];
+        assert_eq!(
+            blob_data.fill(&blobs, 1),
+            Err(BlobProviderError::NotEnoughBlobs { expected: 1, actual: 1 })
+        );
+    }
+
+    #[test]
+    fn test_fill_zero_blob() {
+        let mut blob_data = CeloBlobData::default();
+        let blobs = vec![Box::new(Blob::ZERO)];
+        // consider a blob made entirely of zero bytes a regular blob
+        assert_eq!(blob_data.fill(&blobs, 0), Ok(true));
+    }
+
+    #[test]
+    fn test_fill_blob() {
+        let mut blob_data = CeloBlobData::default();
+        let blobs = vec![Box::new(Blob::with_last_byte(1u8))];
+        assert_eq!(blob_data.fill(&blobs, 0), Ok(true));
+        let expected = Bytes::from([&[0u8; 131071][..], &[1u8]].concat());
+        assert_eq!(blob_data.data, Some(expected));
+    }
+
+    #[test]
+    fn test_blob_data_decode_missing_data() {
+        let blob_data = CeloBlobData::default();
+        assert_eq!(blob_data.decode(), Err(BlobDecodingError::MissingData));
+    }
+
+    #[test]
+    fn test_blob_data_decode_invalid_encoding_version() {
+        let blob_data =
+            CeloBlobData { data: Some(Bytes::from(vec![1u8; 32])), ..Default::default() };
+        assert_eq!(blob_data.decode(), Err(BlobDecodingError::InvalidEncodingVersion));
+    }
+
+    #[test]
+    fn test_blob_data_decode_invalid_length() {
+        let mut data = vec![0u8; 32];
+        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[2] = 0xFF;
+        data[3] = 0xFF;
+        data[4] = 0xFF;
+        let blob_data = CeloBlobData { data: Some(Bytes::from(data)), ..Default::default() };
+        assert_eq!(blob_data.decode(), Err(BlobDecodingError::InvalidLength));
+    }
+
+    #[test]
+    fn test_blob_data_decode() {
+        let mut data = vec![0u8; alloy_eips::eip4844::BYTES_PER_BLOB];
+        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[2] = 0x00;
+        data[3] = 0x00;
+        data[4] = 0x01;
+        let blob_data = CeloBlobData { data: Some(Bytes::from(data)), ..Default::default() };
+        assert_eq!(blob_data.decode(), Ok(Bytes::from(vec![0u8; 1])));
+    }
+
+    #[test]
+    fn test_blob_data_decode_invalid_field_element() {
+        let mut data = vec![0u8; alloy_eips::eip4844::BYTES_PER_BLOB + 10];
+        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[2] = 0x00;
+        data[3] = 0x00;
+        data[4] = 0x01;
+        data[33] = 0x01;
+        let blob_data = CeloBlobData { data: Some(Bytes::from(data)), ..Default::default() };
+        assert_eq!(blob_data.decode(), Err(BlobDecodingError::InvalidFieldElement));
+    }
+
+    #[test]
+    fn test_decode_field_element_missing_data() {
+        let blob_data = CeloBlobData::default();
+        assert_eq!(
+            blob_data.decode_field_element(0, 0, &mut []),
+            Err(BlobDecodingError::MissingData)
+        );
+    }
+
+    #[test]
+    fn test_decode_field_element_invalid_field_element() {
+        let mut data = vec![0u8; 32];
+        data[0] = 0b1100_0000;
+        let blob_data = CeloBlobData { data: Some(Bytes::from(data)), ..Default::default() };
+        assert_eq!(
+            blob_data.decode_field_element(0, 0, &mut []),
+            Err(BlobDecodingError::InvalidFieldElement)
+        );
+    }
+
+    #[test]
+    fn test_decode_field_element() {
+        let mut data = vec![0u8; 32];
+        data[1..32].copy_from_slice(&[1u8; 31]);
+        let blob_data = CeloBlobData { data: Some(Bytes::from(data)), ..Default::default() };
+        let mut output = vec![0u8; 31];
+        assert_eq!(blob_data.decode_field_element(0, 0, &mut output), Ok((0, 32, 32)));
+        assert_eq!(output, vec![1u8; 31]);
+    }
+}

--- a/crates/kona/derive/src/blobs.rs
+++ b/crates/kona/derive/src/blobs.rs
@@ -42,9 +42,6 @@ where
     /// Espresso batch-authentication configuration. When `Some` and active for the L1 origin time
     /// of the block being scanned, event-based batch authentication is used. Otherwise (no config,
     /// or fork not yet active) the source falls back to vanilla OP Stack sender verification.
-    ///
-    /// Bundling the authenticator address, fork time and lookback window together makes the
-    /// "fork scheduled but no authenticator" state unrepresentable.
     pub batch_auth_config: Option<BatchAuthConfig>,
     /// LRU caches for batch auth lookback window traversal (receipts + headers). Present iff
     /// [`Self::batch_auth_config`] is set.
@@ -63,7 +60,7 @@ where
         batcher_address: Address,
         batch_auth_config: Option<BatchAuthConfig>,
     ) -> Self {
-        let auth_cache = batch_auth_config.map(|c| BatchAuthCache::new(c.lookback_window));
+        let auth_cache = batch_auth_config.map(|_| BatchAuthCache::new());
         Self {
             chain_provider,
             blob_fetcher,
@@ -190,7 +187,6 @@ where
                     &mut self.chain_provider,
                     block_ref,
                     config.authenticator_address,
-                    config.lookback_window,
                     cache,
                 )
                 .await
@@ -425,7 +421,7 @@ mod tests {
 
     /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
     fn auth_config(authenticator_address: Address) -> BatchAuthConfig {
-        BatchAuthConfig { authenticator_address, espresso_time: 0, lookback_window: 100 }
+        BatchAuthConfig { authenticator_address, espresso_time: 0 }
     }
 
     #[tokio::test]
@@ -563,11 +559,7 @@ mod tests {
             TestChainProvider::default(),
             TestBlobProvider::default(),
             batch_inbox,
-            Some(BatchAuthConfig {
-                authenticator_address: auth_addr,
-                espresso_time: 1_000,
-                lookback_window: 100,
-            }),
+            Some(BatchAuthConfig { authenticator_address: auth_addr, espresso_time: 1_000 }),
         );
         let tx = test_legacy_tx(batch_inbox);
         let block_info = BlockInfo::default(); // timestamp 0 < espresso_time 1000

--- a/crates/kona/derive/src/blobs.rs
+++ b/crates/kona/derive/src/blobs.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     blob_data::CeloBlobData,
 };
-use alloc::{boxed::Box, collections::BTreeSet, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
 use alloy_primitives::{Address, B256, Bytes};
 use async_trait::async_trait;
@@ -75,17 +75,18 @@ where
     /// Extracts blob data and indexed blob hashes from the given transactions.
     ///
     /// When the Espresso fork is active at `l1_origin_time`, each transaction is authorized via
-    /// the `authenticated_hashes` set; otherwise vanilla OP Stack sender verification against
-    /// `batcher_address` is used. The gating decision is made per-transaction by
-    /// [`is_batch_authorized`] from [`Self::batch_auth_config`] + `l1_origin_time`.
+    /// the `authenticated_hashes` map (commitment → authenticating `caller`); otherwise vanilla
+    /// OP Stack sender verification against `batcher_address` is used. The gating decision is made
+    /// per-transaction by [`is_batch_authorized`] from [`Self::batch_auth_config`] +
+    /// `l1_origin_time`.
     fn extract_blob_data(
         &self,
         txs: Vec<TxEnvelope>,
         batcher_address: Address,
-        authenticated_hashes: Option<&BTreeSet<B256>>,
+        authenticated_hashes: Option<&BTreeMap<B256, Address>>,
         l1_origin_time: u64,
     ) -> (Vec<CeloBlobData>, Vec<B256>) {
-        let empty_set = BTreeSet::new();
+        let empty_set = BTreeMap::new();
         let auth_hashes = authenticated_hashes.unwrap_or(&empty_set);
         let mut data = Vec::new();
         let mut hashes = Vec::new();
@@ -179,7 +180,7 @@ where
         // upstream OP Stack (the BatchAuthenticator events are still emitted on L1 but ignored).
         let espresso_active =
             self.batch_auth_config.is_some_and(|c| c.is_active(block_ref.timestamp));
-        let authenticated_hashes: Option<BTreeSet<B256>> = if espresso_active {
+        let authenticated_hashes: Option<BTreeMap<B256, Address>> = if espresso_active {
             let config = self.batch_auth_config.expect("config present when espresso active");
             let cache = self.auth_cache.as_mut().expect("cache present when config present");
             Some(
@@ -499,6 +500,7 @@ mod tests {
         let batch_inbox = address!("0123456789012345678901234567890123456789");
         let auth_addr = address!("00000000000000000000000000000000000000aa");
         let tx = test_legacy_tx(batch_inbox);
+        let sender = tx.recover_signer().unwrap();
         let data = match &tx {
             TxEnvelope::Legacy(t) => t.tx().input.clone(),
             _ => unreachable!(),
@@ -512,11 +514,13 @@ mod tests {
             Some(auth_config(auth_addr)),
         );
         let block_info = BlockInfo::default();
+        // The commitment is the unindexed data word; the authenticating `caller` (= the batch tx
+        // sender) is the indexed topic.
         let log = Log {
             address: auth_addr,
             data: LogData::new_unchecked(
-                vec![BATCH_INFO_AUTHENTICATED_TOPIC, commitment],
-                Default::default(),
+                vec![BATCH_INFO_AUTHENTICATED_TOPIC, sender.into_word()],
+                commitment.as_slice().to_vec().into(),
             ),
         };
         let receipt =
@@ -524,9 +528,46 @@ mod tests {
         source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
         source.chain_provider.insert_receipts(block_info.hash, vec![receipt]);
 
-        // Post-fork: event authorizes the calldata batch even with a wrong sender.
+        // Post-fork: commitment authenticated and tx sender matches authenticating caller.
         source.load_blobs(&block_info, Address::ZERO).await.unwrap();
         assert_eq!(source.data.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_post_fork_caller_mismatch_rejected() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let tx = test_legacy_tx(batch_inbox);
+        let data = match &tx {
+            TxEnvelope::Legacy(t) => t.tx().input.clone(),
+            _ => unreachable!(),
+        };
+        let commitment = keccak256(&data);
+
+        let mut source = CeloBlobSource::new(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            batch_inbox,
+            Some(auth_config(auth_addr)),
+        );
+        let block_info = BlockInfo::default();
+        // The commitment is authenticated, but by a different caller than the batch tx sender.
+        let other_caller = address!("00000000000000000000000000000000000000bb");
+        let log = Log {
+            address: auth_addr,
+            data: LogData::new_unchecked(
+                vec![BATCH_INFO_AUTHENTICATED_TOPIC, other_caller.into_word()],
+                commitment.as_slice().to_vec().into(),
+            ),
+        };
+        let receipt =
+            Receipt { status: Eip658Value::Eip658(true), logs: vec![log], ..Default::default() };
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        source.chain_provider.insert_receipts(block_info.hash, vec![receipt]);
+
+        // Post-fork: commitment authenticated but tx sender != authenticating caller: rejected.
+        source.load_blobs(&block_info, Address::ZERO).await.unwrap();
+        assert!(source.data.is_empty());
     }
 
     #[tokio::test]

--- a/crates/kona/derive/src/blobs.rs
+++ b/crates/kona/derive/src/blobs.rs
@@ -1,0 +1,682 @@
+//! Celo Blob Data Source with Espresso event-based batch authentication.
+//!
+//! Duplicated from kona's `BlobSource` (celo-kona wraps upstream kona instead of patching it)
+//! with the batch-authentication branch from celo-org/optimism#449 folded in. Pre-fork behaviour
+//! is byte-identical to upstream; post-fork, batches are authorized by `BatchInfoAuthenticated`
+//! events instead of by transaction sender.
+
+use crate::{
+    batch_auth::{
+        BatchAuthCache, BatchAuthConfig, collect_authenticated_batches, compute_blob_batch_hash,
+        compute_calldata_batch_hash, is_batch_authorized,
+    },
+    blob_data::CeloBlobData,
+};
+use alloc::{boxed::Box, collections::BTreeSet, vec::Vec};
+use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
+use alloy_primitives::{Address, B256, Bytes};
+use async_trait::async_trait;
+use kona_derive::{
+    BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError, PipelineErrorKind,
+    PipelineResult, ResetError,
+};
+use kona_protocol::BlockInfo;
+
+/// A data iterator that reads from a blob, with optional Espresso event-based authentication.
+#[derive(Debug, Clone)]
+pub struct CeloBlobSource<F, B>
+where
+    F: ChainProvider + Send,
+    B: BlobProvider + Send,
+{
+    /// Chain provider.
+    pub chain_provider: F,
+    /// Fetches blobs.
+    pub blob_fetcher: B,
+    /// The address of the batcher contract.
+    pub batcher_address: Address,
+    /// Data.
+    pub data: Vec<CeloBlobData>,
+    /// Whether the source is open.
+    pub open: bool,
+    /// Espresso batch-authentication configuration. When `Some` and active for the L1 origin time
+    /// of the block being scanned, event-based batch authentication is used. Otherwise (no config,
+    /// or fork not yet active) the source falls back to vanilla OP Stack sender verification.
+    ///
+    /// Bundling the authenticator address, fork time and lookback window together makes the
+    /// "fork scheduled but no authenticator" state unrepresentable.
+    pub batch_auth_config: Option<BatchAuthConfig>,
+    /// LRU caches for batch auth lookback window traversal (receipts + headers). Present iff
+    /// [`Self::batch_auth_config`] is set.
+    pub(crate) auth_cache: Option<BatchAuthCache>,
+}
+
+impl<F, B> CeloBlobSource<F, B>
+where
+    F: ChainProvider + Send,
+    B: BlobProvider + Send,
+{
+    /// Creates a new blob source.
+    pub fn new(
+        chain_provider: F,
+        blob_fetcher: B,
+        batcher_address: Address,
+        batch_auth_config: Option<BatchAuthConfig>,
+    ) -> Self {
+        let auth_cache = batch_auth_config.map(|c| BatchAuthCache::new(c.lookback_window));
+        Self {
+            chain_provider,
+            blob_fetcher,
+            batcher_address,
+            data: Vec::new(),
+            open: false,
+            batch_auth_config,
+            auth_cache,
+        }
+    }
+
+    /// Extracts blob data and indexed blob hashes from the given transactions.
+    ///
+    /// When the Espresso fork is active at `l1_origin_time`, each transaction is authorized via
+    /// the `authenticated_hashes` set; otherwise vanilla OP Stack sender verification against
+    /// `batcher_address` is used. The gating decision is made per-transaction by
+    /// [`is_batch_authorized`] from [`Self::batch_auth_config`] + `l1_origin_time`.
+    fn extract_blob_data(
+        &self,
+        txs: Vec<TxEnvelope>,
+        batcher_address: Address,
+        authenticated_hashes: Option<&BTreeSet<B256>>,
+        l1_origin_time: u64,
+    ) -> (Vec<CeloBlobData>, Vec<B256>) {
+        let empty_set = BTreeSet::new();
+        let auth_hashes = authenticated_hashes.unwrap_or(&empty_set);
+        let mut data = Vec::new();
+        let mut hashes = Vec::new();
+        for tx in txs {
+            let (tx_kind, calldata, blob_hashes) = match &tx {
+                TxEnvelope::Legacy(tx) => (tx.tx().to(), tx.tx().input.clone(), None),
+                TxEnvelope::Eip2930(tx) => (tx.tx().to(), tx.tx().input.clone(), None),
+                TxEnvelope::Eip1559(tx) => (tx.tx().to(), tx.tx().input.clone(), None),
+                TxEnvelope::Eip4844(blob_tx_wrapper) => match blob_tx_wrapper.tx() {
+                    TxEip4844Variant::TxEip4844(tx) => {
+                        (tx.to(), tx.input.clone(), Some(tx.blob_versioned_hashes.clone()))
+                    }
+                    TxEip4844Variant::TxEip4844WithSidecar(tx) => {
+                        let tx = tx.tx();
+                        (tx.to(), tx.input.clone(), Some(tx.blob_versioned_hashes.clone()))
+                    }
+                },
+                _ => continue,
+            };
+            let Some(to) = tx_kind else { continue };
+
+            if to != self.batcher_address {
+                continue;
+            }
+
+            // Compute the batch hash and check authorization.
+            // For blob txs: hash is keccak256(concat(blob_versioned_hashes))
+            // For calldata txs: hash is keccak256(calldata)
+            let batch_hash = blob_hashes.as_ref().map_or_else(
+                || compute_calldata_batch_hash(&calldata),
+                |bh| compute_blob_batch_hash(bh),
+            );
+
+            if !is_batch_authorized(
+                &tx,
+                batch_hash,
+                self.batch_auth_config.as_ref(),
+                auth_hashes,
+                batcher_address,
+                l1_origin_time,
+            ) {
+                continue;
+            }
+            if tx.tx_type() != TxType::Eip4844 {
+                let blob_data =
+                    CeloBlobData { data: None, calldata: Some(calldata.to_vec().into()) };
+                data.push(blob_data);
+                continue;
+            }
+            if !calldata.is_empty() {
+                let hash = match &tx {
+                    TxEnvelope::Legacy(tx) => Some(tx.hash()),
+                    TxEnvelope::Eip2930(tx) => Some(tx.hash()),
+                    TxEnvelope::Eip1559(tx) => Some(tx.hash()),
+                    TxEnvelope::Eip4844(blob_tx_wrapper) => Some(blob_tx_wrapper.hash()),
+                    _ => None,
+                };
+                tracing::warn!(target: "blob_source", "Blob tx has calldata, which will be ignored: {hash:?}");
+            }
+            let blob_hashes = if let Some(b) = blob_hashes {
+                b
+            } else {
+                continue;
+            };
+            for hash in blob_hashes {
+                hashes.push(hash);
+                data.push(CeloBlobData::default());
+            }
+        }
+        (data, hashes)
+    }
+
+    /// Loads blob data into the source if it is not open.
+    async fn load_blobs(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_address: Address,
+    ) -> Result<(), PipelineErrorKind> {
+        if self.open {
+            return Ok(());
+        }
+
+        let info = self
+            .chain_provider
+            .block_info_and_transactions_by_hash(block_ref.hash)
+            .await
+            .map_err(Into::into)?;
+
+        // Only scan for authenticating events when the fork is active. Pre-fork (or fork not yet
+        // active) the lookback walk is bypassed entirely so derivation is byte-identical to
+        // upstream OP Stack (the BatchAuthenticator events are still emitted on L1 but ignored).
+        let espresso_active =
+            self.batch_auth_config.is_some_and(|c| c.is_active(block_ref.timestamp));
+        let authenticated_hashes: Option<BTreeSet<B256>> = if espresso_active {
+            let config = self.batch_auth_config.expect("config present when espresso active");
+            let cache = self.auth_cache.as_mut().expect("cache present when config present");
+            Some(
+                collect_authenticated_batches(
+                    &mut self.chain_provider,
+                    block_ref,
+                    config.authenticator_address,
+                    config.lookback_window,
+                    cache,
+                )
+                .await
+                .map_err(Into::<PipelineErrorKind>::into)?,
+            )
+        } else {
+            None
+        };
+
+        let (mut data, blob_hashes) = self.extract_blob_data(
+            info.1,
+            batcher_address,
+            authenticated_hashes.as_ref(),
+            block_ref.timestamp,
+        );
+
+        // If there are no hashes, set the calldata and return.
+        if blob_hashes.is_empty() {
+            self.open = true;
+            self.data = data;
+            return Ok(());
+        }
+
+        // Convert via Into<PipelineErrorKind> which routes:
+        //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
+        //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
+        //   others        -> PipelineErrorKind::Critical
+        let blobs = self
+            .blob_fetcher
+            .get_and_validate_blobs(block_ref, &blob_hashes)
+            .await
+            .map_err(Into::<PipelineErrorKind>::into)
+            .inspect_err(|kind| match kind {
+                PipelineErrorKind::Reset(_) => {
+                    tracing::warn!(
+                        target: "blob_source",
+                        block_hash = %block_ref.hash,
+                        block_number = block_ref.number,
+                        timestamp = block_ref.timestamp,
+                        "Blobs permanently unavailable (missed/orphaned beacon slot); \
+                         triggering pipeline reset"
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        target: "blob_source",
+                        block_hash = %block_ref.hash,
+                        block_number = block_ref.number,
+                        timestamp = block_ref.timestamp,
+                        "Failed to fetch blobs: {kind}"
+                    );
+                }
+            })?;
+
+        // Fill the blob pointers.
+        let mut filled_blobs = 0;
+        for blob in &mut data {
+            let should_increment = blob.fill(&blobs, filled_blobs)?;
+            if should_increment {
+                filled_blobs += 1;
+            }
+        }
+
+        // Post-loop over-fill check: if the provider returned more blobs than were
+        // requested, the pipeline state is inconsistent. Reset so the pipeline retries
+        // from a clean state.
+        if filled_blobs < blobs.len() {
+            return Err(
+                ResetError::BlobsOverFill { filled: filled_blobs, returned: blobs.len() }.reset()
+            );
+        }
+
+        self.open = true;
+        self.data = data;
+        Ok(())
+    }
+
+    /// Extracts the next data from the source.
+    // The error type is kona's `PipelineErrorKind`, which is large; this mirrors kona's own
+    // `BlobSource::next_data` and cannot be boxed without diverging from the upstream signature.
+    #[allow(clippy::result_large_err)]
+    fn next_data(&mut self) -> PipelineResult<CeloBlobData> {
+        if self.data.is_empty() {
+            return Err(PipelineError::Eof.temp());
+        }
+
+        Ok(self.data.remove(0))
+    }
+}
+
+#[async_trait]
+impl<F, B> DataAvailabilityProvider for CeloBlobSource<F, B>
+where
+    F: ChainProvider + Sync + Send,
+    B: BlobProvider + Sync + Send,
+{
+    type Item = Bytes;
+
+    async fn next(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_address: Address,
+    ) -> PipelineResult<Self::Item> {
+        self.load_blobs(block_ref, batcher_address).await?;
+
+        let next_data = self.next_data()?;
+        if let Some(c) = next_data.calldata {
+            return Ok(c);
+        }
+
+        // Decode the blob data to raw bytes.
+        // Otherwise, ignore blob and recurse next.
+        match next_data.decode() {
+            Ok(d) => Ok(d),
+            Err(_) => {
+                tracing::warn!(target: "blob_source", "Failed to decode blob data, skipping");
+                self.next(block_ref, batcher_address).await
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        self.data.clear();
+        self.open = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batch_auth::BATCH_INFO_AUTHENTICATED_TOPIC;
+    use alloc::{vec, vec::Vec};
+    use alloy_consensus::{
+        Blob, Eip658Value, Receipt, Signed, TxLegacy, transaction::SignerRecoverable,
+    };
+    use alloy_primitives::{
+        Address, B256, Log, LogData, Signature, TxKind, address, b256, keccak256,
+    };
+    use alloy_rlp::Decodable;
+    use kona_derive::test_utils::{TestBlobProvider, TestChainProvider};
+
+    fn test_legacy_tx(to: Address) -> TxEnvelope {
+        let sig = Signature::test_signature();
+        TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy { to: TxKind::Call(to), ..Default::default() },
+            sig,
+            Default::default(),
+        ))
+    }
+
+    fn default_source() -> CeloBlobSource<TestChainProvider, TestBlobProvider> {
+        CeloBlobSource::new(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            Default::default(),
+            None,
+        )
+    }
+
+    /// A single valid EIP-4844 batcher transaction (carrying 5 blob versioned hashes), decoded
+    /// from a real Sepolia raw tx. Copied from kona's `BlobSource` tests.
+    ///
+    /// <https://sepolia.etherscan.io/getRawTx?tx=0x9a22ccb0029bc8b0ddd073be1a1d923b7ae2b2ea52100bae0db4424f9107e9c0>
+    fn valid_blob_txs() -> Vec<TxEnvelope> {
+        let raw_tx = alloy_primitives::hex::decode("0x03f9011d83aa36a7820fa28477359400852e90edd0008252089411e9ca82a3a762b4b5bd264d4173a242e7a770648080c08504a817c800f8a5a0012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921aa00152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4a0013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7a001148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1a0011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e654901a0c8de4cced43169f9aa3d36506363b2d2c44f6c49fc1fd91ea114c86f3757077ea01e11fdd0d1934eda0492606ee0bb80a7bf8f35cc5f86ec60fe5031ba48bfd544").unwrap();
+        let eip4844 = TxEnvelope::decode(&mut raw_tx.as_slice()).unwrap();
+        vec![eip4844]
+    }
+
+    /// The batcher/sender pair encoded in [`valid_blob_txs`].
+    const BLOB_TX_BATCHER: Address = address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+    const BLOB_TX_SENDER: Address = address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+
+    /// The 5 blob versioned hashes carried by [`valid_blob_txs`].
+    fn blob_tx_hashes() -> [B256; 5] {
+        [
+            b256!("012ec3d6f66766bedb002a190126b3549fce0047de0d4c25cffce0dc1c57921a"),
+            b256!("0152d8e24762ff22b1cfd9f8c0683786a7ca63ba49973818b3d1e9512cd2cec4"),
+            b256!("013b98c6c83e066d5b14af2b85199e3d4fc7d1e778dd53130d180f5077e2d1c7"),
+            b256!("01148b495d6e859114e670ca54fb6e2657f0cbae5b08063605093a4b3dc9f8f1"),
+            b256!("011ac212f13c5dff2b2c6b600a79635103d6f580a4221079951181b25c7e6549"),
+        ]
+    }
+
+    /// A chain provider whose `block_info_and_transactions_by_hash` returns an error mapping to
+    /// [`PipelineErrorKind::Reset`] (matching what `AlloyChainProvider` emits for a 404). Copied
+    /// from kona's `BlobSource` tests to exercise the reset-propagation path.
+    #[derive(Debug, Clone)]
+    struct BlockNotFoundChainProvider;
+
+    #[derive(Debug)]
+    struct BlockNotFoundError;
+
+    impl core::fmt::Display for BlockNotFoundError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "block not found")
+        }
+    }
+
+    impl From<BlockNotFoundError> for PipelineErrorKind {
+        fn from(_: BlockNotFoundError) -> Self {
+            ResetError::BlockNotFound(B256::default().into()).reset()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ChainProvider for BlockNotFoundChainProvider {
+        type Error = BlockNotFoundError;
+
+        async fn header_by_hash(
+            &mut self,
+            _: B256,
+        ) -> Result<alloy_consensus::Header, Self::Error> {
+            Err(BlockNotFoundError)
+        }
+
+        async fn block_info_by_number(&mut self, _: u64) -> Result<BlockInfo, Self::Error> {
+            Err(BlockNotFoundError)
+        }
+
+        async fn receipts_by_hash(&mut self, _: B256) -> Result<Vec<Receipt>, Self::Error> {
+            Err(BlockNotFoundError)
+        }
+
+        async fn block_info_and_transactions_by_hash(
+            &mut self,
+            _: B256,
+        ) -> Result<(BlockInfo, Vec<TxEnvelope>), Self::Error> {
+            Err(BlockNotFoundError)
+        }
+    }
+
+    /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
+    fn auth_config(authenticator_address: Address) -> BatchAuthConfig {
+        BatchAuthConfig { authenticator_address, espresso_time: 0, lookback_window: 100 }
+    }
+
+    #[tokio::test]
+    async fn test_clear() {
+        let mut source = default_source();
+        source.open = true;
+        source.data.push(CeloBlobData::default());
+        source.clear();
+        assert!(source.data.is_empty());
+        assert!(!source.open);
+    }
+
+    // --- Tests ported (adapted to the 4-arg constructor) from kona's `BlobSource`, exercising
+    // the load/next plumbing that is unchanged from upstream. ---
+
+    #[tokio::test]
+    async fn test_load_blobs_open() {
+        let mut source = default_source();
+        source.open = true;
+        assert!(source.load_blobs(&BlockInfo::default(), Address::ZERO).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_chain_provider_err() {
+        let mut source = default_source();
+        assert!(matches!(
+            source.load_blobs(&BlockInfo::default(), Address::ZERO).await,
+            Err(PipelineErrorKind::Temporary(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_chain_provider_empty_txs() {
+        let mut source = default_source();
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, Vec::new());
+        assert!(!source.open);
+        assert!(source.load_blobs(&BlockInfo::default(), Address::ZERO).await.is_ok());
+        assert!(source.data.is_empty());
+        assert!(source.open);
+    }
+
+    #[tokio::test]
+    async fn test_open_empty_data_eof() {
+        let mut source = default_source();
+        source.open = true;
+        let err = source.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Temporary(PipelineError::Eof)));
+    }
+
+    #[tokio::test]
+    async fn test_open_calldata() {
+        let mut source = default_source();
+        source.open = true;
+        source.data.push(CeloBlobData { data: None, calldata: Some(Bytes::default()) });
+        let data = source.next(&BlockInfo::default(), Address::ZERO).await.unwrap();
+        assert_eq!(data, Bytes::default());
+    }
+
+    #[tokio::test]
+    async fn test_pre_fork_sender_path() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let mut source = default_source();
+        source.batcher_address = batch_inbox;
+        let tx = test_legacy_tx(batch_inbox);
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        // Pre-fork: a calldata-carrying tx from the batcher is accepted.
+        source.load_blobs(&block_info, tx.recover_signer().unwrap()).await.unwrap();
+        assert_eq!(source.data.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_post_fork_event_path() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let tx = test_legacy_tx(batch_inbox);
+        let data = match &tx {
+            TxEnvelope::Legacy(t) => t.tx().input.clone(),
+            _ => unreachable!(),
+        };
+        let commitment = keccak256(&data);
+
+        let mut source = CeloBlobSource::new(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            batch_inbox,
+            Some(auth_config(auth_addr)),
+        );
+        let block_info = BlockInfo::default();
+        let log = Log {
+            address: auth_addr,
+            data: LogData::new_unchecked(
+                vec![BATCH_INFO_AUTHENTICATED_TOPIC, commitment],
+                Default::default(),
+            ),
+        };
+        let receipt =
+            Receipt { status: Eip658Value::Eip658(true), logs: vec![log], ..Default::default() };
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        source.chain_provider.insert_receipts(block_info.hash, vec![receipt]);
+
+        // Post-fork: event authorizes the calldata batch even with a wrong sender.
+        source.load_blobs(&block_info, Address::ZERO).await.unwrap();
+        assert_eq!(source.data.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_post_fork_no_event_rejected() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let tx = test_legacy_tx(batch_inbox);
+
+        let mut source = CeloBlobSource::new(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            batch_inbox,
+            Some(auth_config(auth_addr)),
+        );
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        source.chain_provider.insert_receipts(block_info.hash, Vec::new());
+
+        source.load_blobs(&block_info, tx.recover_signer().unwrap()).await.unwrap();
+        assert!(source.data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_configured_but_not_active_uses_sender_path() {
+        // Espresso configured but not yet active at the scanned block's timestamp: must use the
+        // vanilla sender path (byte-identical to upstream OP Stack).
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let mut source = CeloBlobSource::new(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            batch_inbox,
+            Some(BatchAuthConfig {
+                authenticator_address: auth_addr,
+                espresso_time: 1_000,
+                lookback_window: 100,
+            }),
+        );
+        let tx = test_legacy_tx(batch_inbox);
+        let block_info = BlockInfo::default(); // timestamp 0 < espresso_time 1000
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+
+        // Sender matches: accepted via the pre-fork path.
+        source.load_blobs(&block_info, tx.recover_signer().unwrap()).await.unwrap();
+        assert_eq!(source.data.len(), 1);
+    }
+
+    // --- Tests ported (adapted to the 4-arg constructor) from kona's `BlobSource`, exercising the
+    // blob-fetch and reset/EOF routing that is unchanged from upstream. ---
+
+    #[tokio::test]
+    async fn test_blob_source_pipeline_error() {
+        let mut source = default_source();
+        let err = source.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Temporary(PipelineError::Provider(_))));
+    }
+
+    #[tokio::test]
+    async fn test_open_blob_data_decode_missing_data() {
+        let mut source = default_source();
+        source.open = true;
+        source.data.push(CeloBlobData { data: Some(Bytes::from(&[1; 32])), calldata: None });
+        let err = source.next(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Temporary(PipelineError::Eof)));
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_chain_provider_4844_txs_blob_fetch_error() {
+        let mut source = default_source();
+        let block_info = BlockInfo::default();
+        source.batcher_address = BLOB_TX_SENDER;
+        source.blob_fetcher.should_error = true;
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        assert!(matches!(
+            source.load_blobs(&BlockInfo::default(), BLOB_TX_BATCHER).await,
+            Err(PipelineErrorKind::Critical(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_chain_provider_4844_txs_succeeds() {
+        let mut source = default_source();
+        let block_info = BlockInfo::default();
+        source.batcher_address = BLOB_TX_SENDER;
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        for hash in blob_tx_hashes() {
+            source.blob_fetcher.insert_blob(hash, Blob::with_last_byte(1u8));
+        }
+        source.load_blobs(&BlockInfo::default(), BLOB_TX_BATCHER).await.unwrap();
+        assert!(source.open);
+        assert!(!source.data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_not_found_triggers_reset() {
+        let mut source = default_source();
+        let block_info = BlockInfo::default();
+        source.batcher_address = BLOB_TX_SENDER;
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        source.blob_fetcher.should_return_not_found = true;
+        let err = source.load_blobs(&BlockInfo::default(), BLOB_TX_BATCHER).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Reset(_)), "expected Reset, got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_missed_beacon_slot_triggers_pipeline_reset() {
+        let mut source = default_source();
+        let block_info = BlockInfo::default();
+        source.batcher_address = BLOB_TX_SENDER;
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        source.blob_fetcher.should_return_not_found = true;
+        let err = source.next(&BlockInfo::default(), BLOB_TX_BATCHER).await.unwrap_err();
+        assert!(matches!(err, PipelineErrorKind::Reset(_)), "expected Reset, got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_block_not_found_triggers_reset() {
+        let mut source = CeloBlobSource::new(
+            BlockNotFoundChainProvider,
+            TestBlobProvider::default(),
+            Address::ZERO,
+            None,
+        );
+        let err = source.load_blobs(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset when block_info_and_transactions_by_hash returns BlockNotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_blobs_overfill_triggers_reset() {
+        let mut source = default_source();
+        let block_info = BlockInfo::default();
+        source.batcher_address = BLOB_TX_SENDER;
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        // Insert blobs for all the real hashes so fill does not under-fill first.
+        for hash in blob_tx_hashes() {
+            source.blob_fetcher.insert_blob(hash, Blob::with_last_byte(1u8));
+        }
+        // Instruct the mock provider to return one extra blob beyond what was requested.
+        source.blob_fetcher.should_return_extra_blob = true;
+        let err = source.load_blobs(&BlockInfo::default(), BLOB_TX_BATCHER).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset for blob over-fill, got {err:?}"
+        );
+    }
+}

--- a/crates/kona/derive/src/calldata.rs
+++ b/crates/kona/derive/src/calldata.rs
@@ -11,7 +11,7 @@ use crate::batch_auth::{
 };
 use alloc::{
     boxed::Box,
-    collections::{BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
 };
 use alloy_consensus::{Transaction, TxEnvelope};
 use alloy_primitives::{Address, B256, Bytes};
@@ -78,7 +78,7 @@ impl<CP: ChainProvider + Send> CeloCalldataSource<CP> {
         // upstream OP Stack (the BatchAuthenticator events are still emitted on L1 but ignored).
         let espresso_active =
             self.batch_auth_config.is_some_and(|c| c.is_active(block_ref.timestamp));
-        let authenticated_hashes: BTreeSet<B256> = if espresso_active {
+        let authenticated_hashes: BTreeMap<B256, Address> = if espresso_active {
             let config = self.batch_auth_config.expect("config present when espresso active");
             let cache = self.auth_cache.as_mut().expect("cache present when config present");
             collect_authenticated_batches(
@@ -89,7 +89,7 @@ impl<CP: ChainProvider + Send> CeloCalldataSource<CP> {
             )
             .await?
         } else {
-            BTreeSet::new()
+            BTreeMap::new()
         };
 
         self.calldata = txs
@@ -333,13 +333,16 @@ mod tests {
         let batch_inbox = address!("0123456789012345678901234567890123456789");
         let auth_addr = address!("00000000000000000000000000000000000000aa");
         let tx = test_legacy_tx(batch_inbox);
+        let sender = tx.recover_signer().unwrap();
         let data = match &tx {
             TxEnvelope::Legacy(t) => t.tx().input.clone(),
             _ => unreachable!(),
         };
         let commitment = keccak256(&data);
 
-        // Build a block whose receipts contain the authenticating event.
+        // Build a block whose receipts contain the authenticating event. The commitment is the
+        // unindexed data word; the authenticating `caller` (= the batch tx sender) is the indexed
+        // topic.
         let mut source = CeloCalldataSource::new(
             TestChainProvider::default(),
             batch_inbox,
@@ -350,8 +353,8 @@ mod tests {
         let log = Log {
             address: auth_addr,
             data: LogData::new_unchecked(
-                vec![BATCH_INFO_AUTHENTICATED_TOPIC, commitment],
-                Default::default(),
+                vec![BATCH_INFO_AUTHENTICATED_TOPIC, sender.into_word()],
+                commitment.as_slice().to_vec().into(),
             ),
         };
         let receipt =
@@ -359,9 +362,47 @@ mod tests {
         source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
         source.chain_provider.insert_receipts(block_info.hash, vec![receipt]);
 
-        // Post-fork: even with a wrong sender, the event authorizes the batch.
+        // Post-fork: the commitment is authenticated and the tx sender matches the authenticating
+        // caller, so the batch is authorized.
         source.load_calldata(&block_info, Address::ZERO).await.unwrap();
         assert_eq!(source.calldata.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_post_fork_caller_mismatch_rejected() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let tx = test_legacy_tx(batch_inbox);
+        let data = match &tx {
+            TxEnvelope::Legacy(t) => t.tx().input.clone(),
+            _ => unreachable!(),
+        };
+        let commitment = keccak256(&data);
+
+        // The commitment is authenticated, but by a different caller than the batch tx sender.
+        let mut source = CeloCalldataSource::new(
+            TestChainProvider::default(),
+            batch_inbox,
+            Some(auth_config(auth_addr)),
+        );
+
+        let block_info = BlockInfo::default();
+        let other_caller = address!("00000000000000000000000000000000000000bb");
+        let log = Log {
+            address: auth_addr,
+            data: LogData::new_unchecked(
+                vec![BATCH_INFO_AUTHENTICATED_TOPIC, other_caller.into_word()],
+                commitment.as_slice().to_vec().into(),
+            ),
+        };
+        let receipt =
+            Receipt { status: Eip658Value::Eip658(true), logs: vec![log], ..Default::default() };
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        source.chain_provider.insert_receipts(block_info.hash, vec![receipt]);
+
+        // Post-fork: commitment authenticated but tx sender != authenticating caller: rejected.
+        source.load_calldata(&block_info, Address::ZERO).await.unwrap();
+        assert!(source.calldata.is_empty());
     }
 
     #[tokio::test]

--- a/crates/kona/derive/src/calldata.rs
+++ b/crates/kona/derive/src/calldata.rs
@@ -36,9 +36,6 @@ where
     /// Espresso batch-authentication configuration. When `Some` and active for the L1 origin time
     /// of the block being scanned, event-based batch authentication is used. Otherwise (no config,
     /// or fork not yet active) the source falls back to vanilla OP Stack sender verification.
-    ///
-    /// Bundling the authenticator address, fork time and lookback window together makes the
-    /// "fork scheduled but no authenticator" state unrepresentable.
     pub batch_auth_config: Option<BatchAuthConfig>,
     /// LRU caches for batch auth lookback window traversal (receipts + headers). Present iff
     /// [`Self::batch_auth_config`] is set.
@@ -52,7 +49,7 @@ impl<CP: ChainProvider + Send> CeloCalldataSource<CP> {
         batch_inbox_address: Address,
         batch_auth_config: Option<BatchAuthConfig>,
     ) -> Self {
-        let auth_cache = batch_auth_config.map(|c| BatchAuthCache::new(c.lookback_window));
+        let auth_cache = batch_auth_config.map(|_| BatchAuthCache::new());
         Self {
             chain_provider,
             batch_inbox_address,
@@ -88,7 +85,6 @@ impl<CP: ChainProvider + Send> CeloCalldataSource<CP> {
                 &mut self.chain_provider,
                 block_ref,
                 config.authenticator_address,
-                config.lookback_window,
                 cache,
             )
             .await?
@@ -204,7 +200,7 @@ mod tests {
 
     /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
     fn auth_config(authenticator_address: Address) -> BatchAuthConfig {
-        BatchAuthConfig { authenticator_address, espresso_time: 0, lookback_window: 100 }
+        BatchAuthConfig { authenticator_address, espresso_time: 0 }
     }
 
     #[tokio::test]
@@ -398,11 +394,7 @@ mod tests {
         let mut source = CeloCalldataSource::new(
             TestChainProvider::default(),
             batch_inbox,
-            Some(BatchAuthConfig {
-                authenticator_address: auth_addr,
-                espresso_time: 1_000,
-                lookback_window: 100,
-            }),
+            Some(BatchAuthConfig { authenticator_address: auth_addr, espresso_time: 1_000 }),
         );
         let tx = test_legacy_tx(batch_inbox);
         let block_info = BlockInfo::default(); // timestamp 0 < espresso_time 1000
@@ -416,11 +408,7 @@ mod tests {
         let mut source2 = CeloCalldataSource::new(
             TestChainProvider::default(),
             batch_inbox,
-            Some(BatchAuthConfig {
-                authenticator_address: auth_addr,
-                espresso_time: 1_000,
-                lookback_window: 100,
-            }),
+            Some(BatchAuthConfig { authenticator_address: auth_addr, espresso_time: 1_000 }),
         );
         source2.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
         source2.load_calldata(&block_info, Address::ZERO).await.unwrap();

--- a/crates/kona/derive/src/calldata.rs
+++ b/crates/kona/derive/src/calldata.rs
@@ -1,0 +1,429 @@
+//! Celo `CallData` Source with Espresso event-based batch authentication.
+//!
+//! Duplicated from kona's `CalldataSource` (celo-kona wraps upstream kona instead of patching it)
+//! with the batch-authentication branch from celo-org/optimism#449 folded in. Pre-fork behaviour
+//! is byte-identical to upstream; post-fork, batches are authorized by `BatchInfoAuthenticated`
+//! events instead of by transaction sender.
+
+use crate::batch_auth::{
+    BatchAuthCache, BatchAuthConfig, collect_authenticated_batches, compute_calldata_batch_hash,
+    is_batch_authorized,
+};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeSet, VecDeque},
+};
+use alloy_consensus::{Transaction, TxEnvelope};
+use alloy_primitives::{Address, B256, Bytes};
+use async_trait::async_trait;
+use kona_derive::{ChainProvider, DataAvailabilityProvider, PipelineError, PipelineResult};
+use kona_protocol::BlockInfo;
+
+/// A data iterator that reads from calldata, with optional Espresso event-based authentication.
+#[derive(Debug, Clone)]
+pub struct CeloCalldataSource<CP>
+where
+    CP: ChainProvider + Send,
+{
+    /// The chain provider to use for the calldata source.
+    pub chain_provider: CP,
+    /// The batch inbox address.
+    pub batch_inbox_address: Address,
+    /// Current calldata.
+    pub calldata: VecDeque<Bytes>,
+    /// Whether the calldata source is open.
+    pub open: bool,
+    /// Espresso batch-authentication configuration. When `Some` and active for the L1 origin time
+    /// of the block being scanned, event-based batch authentication is used. Otherwise (no config,
+    /// or fork not yet active) the source falls back to vanilla OP Stack sender verification.
+    ///
+    /// Bundling the authenticator address, fork time and lookback window together makes the
+    /// "fork scheduled but no authenticator" state unrepresentable.
+    pub batch_auth_config: Option<BatchAuthConfig>,
+    /// LRU caches for batch auth lookback window traversal (receipts + headers). Present iff
+    /// [`Self::batch_auth_config`] is set.
+    pub(crate) auth_cache: Option<BatchAuthCache>,
+}
+
+impl<CP: ChainProvider + Send> CeloCalldataSource<CP> {
+    /// Creates a new calldata source.
+    pub fn new(
+        chain_provider: CP,
+        batch_inbox_address: Address,
+        batch_auth_config: Option<BatchAuthConfig>,
+    ) -> Self {
+        let auth_cache = batch_auth_config.map(|c| BatchAuthCache::new(c.lookback_window));
+        Self {
+            chain_provider,
+            batch_inbox_address,
+            calldata: VecDeque::new(),
+            open: false,
+            batch_auth_config,
+            auth_cache,
+        }
+    }
+
+    /// Loads the calldata into the source if it is not open.
+    async fn load_calldata(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_address: Address,
+    ) -> Result<(), CP::Error> {
+        if self.open {
+            return Ok(());
+        }
+
+        let (_, txs) =
+            self.chain_provider.block_info_and_transactions_by_hash(block_ref.hash).await?;
+
+        // Only scan for authenticating events when the fork is active. Pre-fork (or fork not yet
+        // active) the lookback walk is bypassed entirely so derivation is byte-identical to
+        // upstream OP Stack (the BatchAuthenticator events are still emitted on L1 but ignored).
+        let espresso_active =
+            self.batch_auth_config.is_some_and(|c| c.is_active(block_ref.timestamp));
+        let authenticated_hashes: BTreeSet<B256> = if espresso_active {
+            let config = self.batch_auth_config.expect("config present when espresso active");
+            let cache = self.auth_cache.as_mut().expect("cache present when config present");
+            collect_authenticated_batches(
+                &mut self.chain_provider,
+                block_ref,
+                config.authenticator_address,
+                config.lookback_window,
+                cache,
+            )
+            .await?
+        } else {
+            BTreeSet::new()
+        };
+
+        self.calldata = txs
+            .iter()
+            .filter_map(|tx| {
+                let (tx_kind, data) = match tx {
+                    TxEnvelope::Legacy(tx) => (tx.tx().to(), tx.tx().input()),
+                    TxEnvelope::Eip2930(tx) => (tx.tx().to(), tx.tx().input()),
+                    TxEnvelope::Eip1559(tx) => (tx.tx().to(), tx.tx().input()),
+                    TxEnvelope::Eip4844(tx) => (tx.tx().to(), tx.tx().input()),
+                    _ => return None,
+                };
+                let to = tx_kind?;
+
+                if to != self.batch_inbox_address {
+                    return None;
+                }
+                if !is_batch_authorized(
+                    tx,
+                    compute_calldata_batch_hash(data),
+                    self.batch_auth_config.as_ref(),
+                    &authenticated_hashes,
+                    batcher_address,
+                    block_ref.timestamp,
+                ) {
+                    return None;
+                }
+                Some(data.to_vec().into())
+            })
+            .collect::<VecDeque<_>>();
+
+        self.open = true;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<CP: ChainProvider + Send> DataAvailabilityProvider for CeloCalldataSource<CP> {
+    type Item = Bytes;
+
+    async fn next(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_address: Address,
+    ) -> PipelineResult<Self::Item> {
+        self.load_calldata(block_ref, batcher_address).await.map_err(Into::into)?;
+        self.calldata.pop_front().ok_or(PipelineError::Eof.temp())
+    }
+
+    fn clear(&mut self) {
+        self.calldata.clear();
+        self.open = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batch_auth::BATCH_INFO_AUTHENTICATED_TOPIC;
+    use alloc::{vec, vec::Vec};
+    use alloy_consensus::{
+        Eip658Value, Receipt, Signed, TxEip2930, TxEip4844, TxEip4844Variant, TxEip7702, TxLegacy,
+        transaction::SignerRecoverable,
+    };
+    use alloy_primitives::{Address, Log, LogData, Signature, TxKind, address, keccak256};
+    use kona_derive::{PipelineErrorKind, test_utils::TestChainProvider};
+
+    fn test_legacy_tx(to: Address) -> TxEnvelope {
+        let sig = Signature::test_signature();
+        TxEnvelope::Legacy(Signed::new_unchecked(
+            TxLegacy { to: TxKind::Call(to), ..Default::default() },
+            sig,
+            Default::default(),
+        ))
+    }
+
+    fn test_eip2930_tx(to: Address) -> TxEnvelope {
+        let sig = Signature::test_signature();
+        TxEnvelope::Eip2930(Signed::new_unchecked(
+            TxEip2930 { to: TxKind::Call(to), ..Default::default() },
+            sig,
+            Default::default(),
+        ))
+    }
+
+    fn test_eip7702_tx(to: Address) -> TxEnvelope {
+        let sig = Signature::test_signature();
+        TxEnvelope::Eip7702(Signed::new_unchecked(
+            TxEip7702 { to, ..Default::default() },
+            sig,
+            Default::default(),
+        ))
+    }
+
+    fn test_blob_tx(to: Address) -> TxEnvelope {
+        let sig = Signature::test_signature();
+        TxEnvelope::Eip4844(Signed::new_unchecked(
+            TxEip4844Variant::TxEip4844(TxEip4844 { to, ..Default::default() }),
+            sig,
+            Default::default(),
+        ))
+    }
+
+    fn default_test_calldata_source() -> CeloCalldataSource<TestChainProvider> {
+        CeloCalldataSource::new(TestChainProvider::default(), Default::default(), None)
+    }
+
+    /// A `BatchAuthConfig` active from genesis (`espresso_time = 0`).
+    fn auth_config(authenticator_address: Address) -> BatchAuthConfig {
+        BatchAuthConfig { authenticator_address, espresso_time: 0, lookback_window: 100 }
+    }
+
+    #[tokio::test]
+    async fn test_clear_calldata() {
+        let mut source = default_test_calldata_source();
+        source.open = true;
+        source.calldata.push_back(Bytes::default());
+        source.clear();
+        assert!(source.calldata.is_empty());
+        assert!(!source.open);
+    }
+
+    // --- Tests ported verbatim (adapted to the 3-arg constructor) from kona's `CalldataSource`,
+    // exercising the tx-type filtering and error paths that are unchanged from upstream. ---
+
+    #[tokio::test]
+    async fn test_load_calldata_open() {
+        let mut source = default_test_calldata_source();
+        source.open = true;
+        assert!(source.load_calldata(&BlockInfo::default(), Address::ZERO).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_calldata_provider_err() {
+        let mut source = default_test_calldata_source();
+        assert!(source.load_calldata(&BlockInfo::default(), Address::ZERO).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_load_calldata_chain_provider_empty_txs() {
+        let mut source = default_test_calldata_source();
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, Vec::new());
+        assert!(!source.open);
+        assert!(source.load_calldata(&BlockInfo::default(), Address::ZERO).await.is_ok());
+        assert!(source.calldata.is_empty());
+        assert!(source.open);
+    }
+
+    #[tokio::test]
+    async fn test_load_calldata_wrong_batch_inbox_address() {
+        let batch_inbox_address = address!("0123456789012345678901234567890123456789");
+        let mut source = default_test_calldata_source();
+        let block_info = BlockInfo::default();
+        let tx = test_legacy_tx(batch_inbox_address);
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        assert!(!source.open);
+        // Source `batch_inbox_address` is the default (zero), so the tx is filtered out.
+        assert!(source.load_calldata(&BlockInfo::default(), Address::ZERO).await.is_ok());
+        assert!(source.calldata.is_empty());
+        assert!(source.open);
+    }
+
+    #[tokio::test]
+    async fn test_load_calldata_valid_eip2930_tx() {
+        let batch_inbox_address = address!("0123456789012345678901234567890123456789");
+        let mut source = default_test_calldata_source();
+        source.batch_inbox_address = batch_inbox_address;
+        let tx = test_eip2930_tx(batch_inbox_address);
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        source.load_calldata(&BlockInfo::default(), tx.recover_signer().unwrap()).await.unwrap();
+        assert_eq!(source.calldata.len(), 1);
+        assert!(source.open);
+    }
+
+    #[tokio::test]
+    async fn test_load_calldata_valid_blob_tx() {
+        let batch_inbox_address = address!("0123456789012345678901234567890123456789");
+        let mut source = default_test_calldata_source();
+        source.batch_inbox_address = batch_inbox_address;
+        let tx = test_blob_tx(batch_inbox_address);
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        source.load_calldata(&BlockInfo::default(), tx.recover_signer().unwrap()).await.unwrap();
+        assert_eq!(source.calldata.len(), 1);
+        assert!(source.open);
+    }
+
+    #[tokio::test]
+    async fn test_load_calldata_eip7702_tx_ignored() {
+        let batch_inbox_address = address!("0123456789012345678901234567890123456789");
+        let mut source = default_test_calldata_source();
+        source.batch_inbox_address = batch_inbox_address;
+        let tx = test_eip7702_tx(batch_inbox_address);
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        // EIP-7702 txs are not a recognized batch-carrier and must be ignored.
+        source.load_calldata(&BlockInfo::default(), tx.recover_signer().unwrap()).await.unwrap();
+        assert!(source.calldata.is_empty());
+        assert!(source.open);
+    }
+
+    #[tokio::test]
+    async fn test_next_err_loading_calldata() {
+        let mut source = default_test_calldata_source();
+        assert!(matches!(
+            source.next(&BlockInfo::default(), Address::ZERO).await,
+            Err(PipelineErrorKind::Temporary(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_pre_fork_valid_sender() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let mut source = default_test_calldata_source();
+        source.batch_inbox_address = batch_inbox;
+        let tx = test_legacy_tx(batch_inbox);
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        // Pre-fork: sender must match the batcher address.
+        source.load_calldata(&BlockInfo::default(), tx.recover_signer().unwrap()).await.unwrap();
+        assert_eq!(source.calldata.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_pre_fork_wrong_sender_rejected() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let mut source = default_test_calldata_source();
+        source.batch_inbox_address = batch_inbox;
+        let tx = test_legacy_tx(batch_inbox);
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        source.load_calldata(&BlockInfo::default(), Address::ZERO).await.unwrap();
+        assert!(source.calldata.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_post_fork_requires_event() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let tx = test_legacy_tx(batch_inbox);
+        let data = match &tx {
+            TxEnvelope::Legacy(t) => t.tx().input.clone(),
+            _ => unreachable!(),
+        };
+        let commitment = keccak256(&data);
+
+        // Build a block whose receipts contain the authenticating event.
+        let mut source = CeloCalldataSource::new(
+            TestChainProvider::default(),
+            batch_inbox,
+            Some(auth_config(auth_addr)),
+        );
+
+        let block_info = BlockInfo::default();
+        let log = Log {
+            address: auth_addr,
+            data: LogData::new_unchecked(
+                vec![BATCH_INFO_AUTHENTICATED_TOPIC, commitment],
+                Default::default(),
+            ),
+        };
+        let receipt =
+            Receipt { status: Eip658Value::Eip658(true), logs: vec![log], ..Default::default() };
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        source.chain_provider.insert_receipts(block_info.hash, vec![receipt]);
+
+        // Post-fork: even with a wrong sender, the event authorizes the batch.
+        source.load_calldata(&block_info, Address::ZERO).await.unwrap();
+        assert_eq!(source.calldata.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_post_fork_no_event_rejected() {
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let tx = test_legacy_tx(batch_inbox);
+
+        let mut source = CeloCalldataSource::new(
+            TestChainProvider::default(),
+            batch_inbox,
+            Some(auth_config(auth_addr)),
+        );
+        let block_info = BlockInfo::default();
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+        source.chain_provider.insert_receipts(block_info.hash, Vec::new());
+
+        // Post-fork with no authenticating event: rejected even though sender matches.
+        source.load_calldata(&block_info, tx.recover_signer().unwrap()).await.unwrap();
+        assert!(source.calldata.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_configured_but_not_active_uses_sender_path() {
+        // Espresso is configured but the fork activates in the future, so the block being scanned
+        // (timestamp 0) is pre-fork and must use vanilla sender verification — byte-identical to
+        // upstream OP Stack.
+        let batch_inbox = address!("0123456789012345678901234567890123456789");
+        let auth_addr = address!("00000000000000000000000000000000000000aa");
+        let mut source = CeloCalldataSource::new(
+            TestChainProvider::default(),
+            batch_inbox,
+            Some(BatchAuthConfig {
+                authenticator_address: auth_addr,
+                espresso_time: 1_000,
+                lookback_window: 100,
+            }),
+        );
+        let tx = test_legacy_tx(batch_inbox);
+        let block_info = BlockInfo::default(); // timestamp 0 < espresso_time 1000
+        source.chain_provider.insert_block_with_transactions(0, block_info, vec![tx.clone()]);
+
+        // Sender matches: accepted via the pre-fork path (no event needed).
+        source.load_calldata(&block_info, tx.recover_signer().unwrap()).await.unwrap();
+        assert_eq!(source.calldata.len(), 1);
+
+        // Sender mismatch: rejected (pre-fork path, no event fallback).
+        let mut source2 = CeloCalldataSource::new(
+            TestChainProvider::default(),
+            batch_inbox,
+            Some(BatchAuthConfig {
+                authenticator_address: auth_addr,
+                espresso_time: 1_000,
+                lookback_window: 100,
+            }),
+        );
+        source2.chain_provider.insert_block_with_transactions(0, block_info, vec![tx]);
+        source2.load_calldata(&block_info, Address::ZERO).await.unwrap();
+        assert!(source2.calldata.is_empty());
+    }
+}

--- a/crates/kona/derive/src/ethereum.rs
+++ b/crates/kona/derive/src/ethereum.rs
@@ -57,13 +57,10 @@ where
         blobs: B,
         cfg: &CeloRollupConfig,
     ) -> Result<Self, CeloEspressoConfigError> {
-        let batch_auth_config = cfg.batch_auth_params()?.map(
-            |(authenticator_address, espresso_time, lookback_window)| BatchAuthConfig {
-                authenticator_address,
-                espresso_time,
-                lookback_window,
-            },
-        );
+        let batch_auth_config =
+            cfg.batch_auth_params()?.map(|(authenticator_address, espresso_time)| {
+                BatchAuthConfig { authenticator_address, espresso_time }
+            });
         Ok(Self {
             ecotone_timestamp: cfg.op_rollup_config.hardforks.ecotone_time,
             blob_source: CeloBlobSource::new(
@@ -135,7 +132,6 @@ mod tests {
         cfg.espresso.batch_authenticator_address =
             Some(address!("00000000000000000000000000000000000000aa"));
         cfg.espresso.espresso_time = Some(42);
-        cfg.espresso.batch_auth_lookback_window = Some(7);
 
         let ds = CeloEthereumDataSource::new_from_parts(
             TestChainProvider::default(),
@@ -149,7 +145,6 @@ mod tests {
             address!("00000000000000000000000000000000000000aa")
         );
         assert_eq!(calldata_cfg.espresso_time, 42);
-        assert_eq!(calldata_cfg.lookback_window, 7);
         assert!(ds.blob_source.batch_auth_config.is_some());
     }
 

--- a/crates/kona/derive/src/ethereum.rs
+++ b/crates/kona/derive/src/ethereum.rs
@@ -1,0 +1,169 @@
+//! Contains the [`CeloEthereumDataSource`], a Celo-specific [`DataAvailabilityProvider`] that
+//! mirrors kona's `EthereumDataSource` but routes through the Espresso-aware
+//! [`CeloCalldataSource`] / [`CeloBlobSource`].
+//!
+//! celo-kona wraps upstream kona instead of patching it at source, so this factory duplicates the
+//! ecotone calldata/blob dispatch from kona's `EthereumDataSource` while threading the Espresso
+//! batch-authentication configuration (from celo-org/optimism#449) into the inner sources.
+
+use crate::{batch_auth::BatchAuthConfig, blobs::CeloBlobSource, calldata::CeloCalldataSource};
+use alloc::{boxed::Box, fmt::Debug};
+use alloy_primitives::{Address, Bytes};
+use async_trait::async_trait;
+use celo_genesis::{CeloEspressoConfigError, CeloRollupConfig};
+use kona_derive::{BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineResult};
+use kona_protocol::BlockInfo;
+
+/// A factory for creating a Celo-aware Ethereum data source provider.
+#[derive(Debug, Clone)]
+pub struct CeloEthereumDataSource<C, B>
+where
+    C: ChainProvider + Send + Clone,
+    B: BlobProvider + Send + Clone,
+{
+    /// The ecotone timestamp.
+    pub ecotone_timestamp: Option<u64>,
+    /// The blob source.
+    pub blob_source: CeloBlobSource<C, B>,
+    /// The calldata source.
+    pub calldata_source: CeloCalldataSource<C>,
+}
+
+impl<C, B> CeloEthereumDataSource<C, B>
+where
+    C: ChainProvider + Send + Clone + Debug,
+    B: BlobProvider + Send + Clone + Debug,
+{
+    /// Instantiates a new [`CeloEthereumDataSource`] from its inner sources.
+    pub const fn new(
+        blob_source: CeloBlobSource<C, B>,
+        calldata_source: CeloCalldataSource<C>,
+        ecotone_timestamp: Option<u64>,
+    ) -> Self {
+        Self { ecotone_timestamp, blob_source, calldata_source }
+    }
+
+    /// Instantiates a new [`CeloEthereumDataSource`] from parts, reading Espresso batch-auth
+    /// settings off the [`CeloRollupConfig`].
+    ///
+    /// This is the Celo analogue of kona's `EthereumDataSource::new_from_parts`.
+    ///
+    /// Returns [`CeloEspressoConfigError::MissingAuthenticatorAddress`] if the rollup config
+    /// schedules an Espresso fork (`espresso_time`) without a usable `BatchAuthenticator` address.
+    /// The boot path validates this up front, but the check is repeated here so the invariant
+    /// travels with the constructor.
+    pub fn new_from_parts(
+        provider: C,
+        blobs: B,
+        cfg: &CeloRollupConfig,
+    ) -> Result<Self, CeloEspressoConfigError> {
+        let batch_auth_config = cfg.batch_auth_params()?.map(
+            |(authenticator_address, espresso_time, lookback_window)| BatchAuthConfig {
+                authenticator_address,
+                espresso_time,
+                lookback_window,
+            },
+        );
+        Ok(Self {
+            ecotone_timestamp: cfg.op_rollup_config.hardforks.ecotone_time,
+            blob_source: CeloBlobSource::new(
+                provider.clone(),
+                blobs,
+                cfg.op_rollup_config.batch_inbox_address,
+                batch_auth_config,
+            ),
+            calldata_source: CeloCalldataSource::new(
+                provider,
+                cfg.op_rollup_config.batch_inbox_address,
+                batch_auth_config,
+            ),
+        })
+    }
+}
+
+#[async_trait]
+impl<C, B> DataAvailabilityProvider for CeloEthereumDataSource<C, B>
+where
+    C: ChainProvider + Send + Sync + Clone + Debug,
+    B: BlobProvider + Send + Sync + Clone + Debug,
+{
+    type Item = Bytes;
+
+    async fn next(
+        &mut self,
+        block_ref: &BlockInfo,
+        batcher_address: Address,
+    ) -> PipelineResult<Self::Item> {
+        let ecotone_enabled = self.ecotone_timestamp.is_some_and(|e| block_ref.timestamp >= e);
+        if ecotone_enabled {
+            self.blob_source.next(block_ref, batcher_address).await
+        } else {
+            self.calldata_source.next(block_ref, batcher_address).await
+        }
+    }
+
+    fn clear(&mut self) {
+        self.blob_source.clear();
+        self.calldata_source.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+    use celo_genesis::CeloRollupConfig;
+    use kona_derive::test_utils::{TestBlobProvider, TestChainProvider};
+    use kona_genesis::RollupConfig;
+
+    #[test]
+    fn test_new_from_parts_disabled_batch_auth() {
+        let cfg = CeloRollupConfig::new(RollupConfig::default());
+        let ds = CeloEthereumDataSource::new_from_parts(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(ds.calldata_source.batch_auth_config.is_none());
+        assert!(ds.blob_source.batch_auth_config.is_none());
+    }
+
+    #[test]
+    fn test_new_from_parts_enabled_batch_auth() {
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        cfg.espresso.batch_authenticator_address =
+            Some(address!("00000000000000000000000000000000000000aa"));
+        cfg.espresso.espresso_time = Some(42);
+        cfg.espresso.batch_auth_lookback_window = Some(7);
+
+        let ds = CeloEthereumDataSource::new_from_parts(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            &cfg,
+        )
+        .unwrap();
+        let calldata_cfg = ds.calldata_source.batch_auth_config.expect("batch auth config present");
+        assert_eq!(
+            calldata_cfg.authenticator_address,
+            address!("00000000000000000000000000000000000000aa")
+        );
+        assert_eq!(calldata_cfg.espresso_time, 42);
+        assert_eq!(calldata_cfg.lookback_window, 7);
+        assert!(ds.blob_source.batch_auth_config.is_some());
+    }
+
+    #[test]
+    fn test_new_from_parts_espresso_without_authenticator_errors() {
+        // espresso_time set but no authenticator address: hard error.
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        cfg.espresso.espresso_time = Some(42);
+        let err = CeloEthereumDataSource::new_from_parts(
+            TestChainProvider::default(),
+            TestBlobProvider::default(),
+            &cfg,
+        )
+        .unwrap_err();
+        assert_eq!(err, CeloEspressoConfigError::MissingAuthenticatorAddress);
+    }
+}

--- a/crates/kona/derive/src/lib.rs
+++ b/crates/kona/derive/src/lib.rs
@@ -1,0 +1,34 @@
+//! Celo-specific derivation-pipeline extensions.
+//!
+//! This crate provides the Celo analogue of kona's `EthereumDataSource`
+//! ([`CeloEthereumDataSource`]) with Espresso event-based batch authentication folded in. It
+//! wraps/duplicates kona's data sources rather than patching upstream kona, mirroring how the rest
+//! of celo-kona consumes the OP Stack rust crates.
+//!
+//! The batch-authentication logic is the Rust companion to the op-node changes in
+//! celo-org/optimism#445, originally drafted against vendored kona in celo-org/optimism#449 and
+//! relocated here.
+
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+mod batch_auth;
+pub use batch_auth::{
+    BATCH_INFO_AUTHENTICATED_TOPIC, BatchAuthCache, BatchAuthConfig,
+    collect_auth_events_from_receipts, collect_authenticated_batches, compute_blob_batch_hash,
+    compute_calldata_batch_hash, is_batch_authorized,
+};
+
+mod blob_data;
+pub use blob_data::CeloBlobData;
+
+mod calldata;
+pub use calldata::CeloCalldataSource;
+
+mod blobs;
+pub use blobs::CeloBlobSource;
+
+mod ethereum;
+pub use ethereum::CeloEthereumDataSource;

--- a/crates/kona/executor/src/test_utils.rs
+++ b/crates/kona/executor/src/test_utils.rs
@@ -53,7 +53,7 @@ pub async fn load_and_execute_fixture(
 
     // Wrap RollupConfig to CeloRollupConfig
     let rollup_config = fixture.op_executor_test_fixture.rollup_config.clone();
-    let celo_rollup_config = CeloRollupConfig(rollup_config);
+    let celo_rollup_config = CeloRollupConfig::new(rollup_config);
     let mut executor = CeloStatelessL2Builder::new(
         &celo_rollup_config,
         CeloEvmFactory::default(),
@@ -191,7 +191,7 @@ impl ExecutorTestFixtureCreator {
         let fixture_path = self.op_executor_test_fixture_creator.data_dir.join("fixture.json");
         let fixture = ExecutorTestFixture {
             op_executor_test_fixture: OpExecutorTestFixture {
-                rollup_config: rollup_config.0.clone(),
+                rollup_config: rollup_config.op_rollup_config.clone(),
                 parent_header: parent_header.inner().clone(),
                 expected_block_hash: executing_header.hash_slow(),
                 executing_payload: payload_attrs.op_payload_attributes.clone(),

--- a/crates/kona/executor/src/util.rs
+++ b/crates/kona/executor/src/util.rs
@@ -166,7 +166,7 @@ mod test {
 
     #[test]
     fn test_encode_holocene_eip_1559_params_missing() {
-        let cfg = CeloRollupConfig(RollupConfig {
+        let cfg = CeloRollupConfig::new(RollupConfig {
             chain_op_config: BaseFeeConfig {
                 eip1559_denominator: 32,
                 eip1559_elasticity: 64,
@@ -183,7 +183,7 @@ mod test {
     fn test_encode_holocene_eip_1559_params_default() {
         // Use different values for pre-canyon and canyon denominators to verify
         // we're using the canyon params (0x30) not pre-canyon (0x20)
-        let cfg = CeloRollupConfig(RollupConfig {
+        let cfg = CeloRollupConfig::new(RollupConfig {
             chain_op_config: BaseFeeConfig {
                 eip1559_denominator: 32,        // 0x20 - pre-canyon
                 eip1559_elasticity: 64,         // 0x40
@@ -202,7 +202,7 @@ mod test {
 
     #[test]
     fn test_encode_holocene_eip_1559_params() {
-        let cfg = CeloRollupConfig(RollupConfig {
+        let cfg = CeloRollupConfig::new(RollupConfig {
             chain_op_config: BaseFeeConfig {
                 eip1559_denominator: 32,
                 eip1559_elasticity: 64,

--- a/crates/kona/genesis/src/lib.rs
+++ b/crates/kona/genesis/src/lib.rs
@@ -6,4 +6,7 @@
 extern crate alloc;
 
 mod rollup;
-pub use rollup::CeloRollupConfig;
+pub use rollup::{
+    CeloEspressoConfig, CeloEspressoConfigError, CeloRollupConfig,
+    DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW,
+};

--- a/crates/kona/genesis/src/lib.rs
+++ b/crates/kona/genesis/src/lib.rs
@@ -7,6 +7,5 @@ extern crate alloc;
 
 mod rollup;
 pub use rollup::{
-    CeloEspressoConfig, CeloEspressoConfigError, CeloRollupConfig,
-    DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW,
+    BATCH_AUTH_LOOKBACK_WINDOW, CeloEspressoConfig, CeloEspressoConfigError, CeloRollupConfig,
 };

--- a/crates/kona/genesis/src/rollup.rs
+++ b/crates/kona/genesis/src/rollup.rs
@@ -4,19 +4,15 @@ use alloy_op_hardforks::{OpHardfork, OpHardforks};
 use alloy_primitives::Address;
 use kona_genesis::RollupConfig;
 
-/// The default batch-auth lookback window, in L1 blocks.
+/// The batch-auth lookback window, in L1 blocks.
 ///
 /// The scan covers the batch's L1 origin block plus this many ancestor blocks — i.e. an
 /// inclusive range of `window + 1` blocks (see `celo_derive::collect_authenticated_batches`).
 /// Roughly 20 minutes of ancestry on Ethereum mainnet (12s blocks).
 ///
-/// This parameter affects derivation consensus, so it must remain a single value across all
-/// participants for the lifetime of the chain, and must match the op-node batcher/verifier. It is
-/// configured per-chain via `rollup.json` rather than as a per-operator CLI flag.
-///
 /// The constant is duplicated here (rather than added to upstream `kona-genesis`) because
 /// celo-kona wraps upstream kona instead of patching it at source.
-pub const DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW: u64 = 100;
+pub const BATCH_AUTH_LOOKBACK_WINDOW: u64 = 100;
 
 /// Celo-specific Espresso batch-authentication configuration.
 ///
@@ -43,14 +39,6 @@ pub struct CeloEspressoConfig {
     /// authenticate batches.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub batch_authenticator_address: Option<Address>,
-    /// Number of L1 blocks before the batch submission to scan for a `BatchInfoAuthenticated`
-    /// event. When `None`, defaults to [`DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW`] via
-    /// [`CeloRollupConfig::batch_auth_lookback_window`].
-    ///
-    /// This must remain a single value across all participants for the chain's lifetime, so it
-    /// is configured per-chain in `rollup.json` rather than via a CLI flag.
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
-    pub batch_auth_lookback_window: Option<u64>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Deref, derive_more::DerefMut)]
@@ -76,11 +64,7 @@ impl CeloRollupConfig {
     pub const fn new(op_rollup_config: RollupConfig) -> Self {
         Self {
             op_rollup_config,
-            espresso: CeloEspressoConfig {
-                espresso_time: None,
-                batch_authenticator_address: None,
-                batch_auth_lookback_window: None,
-            },
+            espresso: CeloEspressoConfig { espresso_time: None, batch_authenticator_address: None },
         }
     }
 
@@ -91,12 +75,6 @@ impl CeloRollupConfig {
     /// events instead of relying on sender verification.
     pub fn is_batch_auth_enabled(&self) -> bool {
         self.espresso.batch_authenticator_address.is_some_and(|addr| !addr.is_zero())
-    }
-
-    /// Returns the configured batch auth lookback window, falling back to
-    /// [`DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW`] when unset.
-    pub fn batch_auth_lookback_window(&self) -> u64 {
-        self.espresso.batch_auth_lookback_window.unwrap_or(DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW)
     }
 
     /// Returns true if Espresso event-only batch authorization is active at the given L1 origin
@@ -120,17 +98,15 @@ impl CeloRollupConfig {
     /// - `Ok(None)` when no `espresso_time` is configured (Espresso is off; the derivation pipeline
     ///   runs vanilla OP Stack semantics). A `BatchAuthenticator` address without an
     ///   `espresso_time` is treated as "not yet scheduled" and likewise yields `None`.
-    /// - `Ok(Some((authenticator_address, espresso_time, lookback_window)))` when both an
-    ///   `espresso_time` and a non-zero authenticator address are configured.
+    /// - `Ok(Some((authenticator_address, espresso_time)))` when both an `espresso_time` and a
+    ///   non-zero authenticator address are configured.
     /// - `Err(MissingAuthenticatorAddress)` when `espresso_time` is set but no usable authenticator
     ///   address is configured (missing or zero) — otherwise no batch could ever be authorized
     ///   post-fork and derivation would silently stall at the fork boundary.
     ///
-    /// The tuple bundles the three coupled parameters so downstream code cannot represent the
+    /// The tuple bundles the two coupled parameters so downstream code cannot represent the
     /// illegal "fork scheduled but no authenticator" state.
-    pub fn batch_auth_params(
-        &self,
-    ) -> Result<Option<(Address, u64, u64)>, CeloEspressoConfigError> {
+    pub fn batch_auth_params(&self) -> Result<Option<(Address, u64)>, CeloEspressoConfigError> {
         let Some(espresso_time) = self.espresso.espresso_time else {
             return Ok(None);
         };
@@ -139,7 +115,7 @@ impl CeloRollupConfig {
             .batch_authenticator_address
             .filter(|addr| !addr.is_zero())
             .ok_or(CeloEspressoConfigError::MissingAuthenticatorAddress)?;
-        Ok(Some((authenticator_address, espresso_time, self.batch_auth_lookback_window())))
+        Ok(Some((authenticator_address, espresso_time)))
     }
 
     /// Validates that the Espresso batch-authentication settings are internally consistent.
@@ -196,8 +172,6 @@ impl<'de> serde::Deserialize<'de> for CeloRollupConfig {
             espresso_time: take_u64(&mut json_obj, "espresso_time")
                 .map_err(serde::de::Error::custom)?,
             batch_authenticator_address: take_address(&mut json_obj, "batch_authenticator_address")
-                .map_err(serde::de::Error::custom)?,
-            batch_auth_lookback_window: take_u64(&mut json_obj, "batch_auth_lookback_window")
                 .map_err(serde::de::Error::custom)?,
         };
 
@@ -379,7 +353,6 @@ mod tests {
         assert_eq!(deserialized.espresso, CeloEspressoConfig::default());
         assert!(!deserialized.is_batch_auth_enabled());
         assert!(!deserialized.is_espresso_active(u64::MAX));
-        assert_eq!(deserialized.batch_auth_lookback_window(), DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW);
     }
 
     #[test]
@@ -399,7 +372,6 @@ mod tests {
     fn test_batch_auth_helpers() {
         let mut cfg = CeloRollupConfig::new(RollupConfig::default());
         assert!(!cfg.is_batch_auth_enabled());
-        assert_eq!(cfg.batch_auth_lookback_window(), DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW);
 
         // Zero address does not enable batch auth.
         cfg.espresso.batch_authenticator_address = Some(Address::ZERO);
@@ -408,9 +380,6 @@ mod tests {
         cfg.espresso.batch_authenticator_address =
             Some(address!("1234567890123456789012345678901234567890"));
         assert!(cfg.is_batch_auth_enabled());
-
-        cfg.espresso.batch_auth_lookback_window = Some(7);
-        assert_eq!(cfg.batch_auth_lookback_window(), 7);
     }
 
     #[test]
@@ -455,18 +424,11 @@ mod tests {
         cfg.espresso.batch_authenticator_address = Some(auth);
         assert_eq!(cfg.batch_auth_params(), Ok(None));
 
-        // espresso_time + valid authenticator => bundled params with default window.
+        // espresso_time + valid authenticator => bundled 2-tuple (no lookback window).
         let mut cfg = CeloRollupConfig::new(RollupConfig::default());
         cfg.espresso.espresso_time = Some(42);
         cfg.espresso.batch_authenticator_address = Some(auth);
-        assert_eq!(
-            cfg.batch_auth_params(),
-            Ok(Some((auth, 42, DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW)))
-        );
-
-        // Explicit lookback window is threaded through.
-        cfg.espresso.batch_auth_lookback_window = Some(7);
-        assert_eq!(cfg.batch_auth_params(), Ok(Some((auth, 42, 7))));
+        assert_eq!(cfg.batch_auth_params(), Ok(Some((auth, 42))));
 
         // espresso_time without authenticator (or zero) => hard error.
         let mut cfg = CeloRollupConfig::new(RollupConfig::default());
@@ -508,7 +470,6 @@ mod tests {
           "cel2_time": 0,
           "espresso_time": 1234,
           "batch_authenticator_address": "0x00000000000000000000000000000000000000aa",
-          "batch_auth_lookback_window": 42,
           "batch_inbox_address": "0xff00000000000000000000000000000000042069",
           "deposit_contract_address": "0x08073dc48dde578137b8af042bcbc1c2491f1eb2",
           "l1_system_config_address": "0x94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710",
@@ -522,10 +483,8 @@ mod tests {
             cfg.espresso.batch_authenticator_address,
             Some(address!("00000000000000000000000000000000000000aa"))
         );
-        assert_eq!(cfg.espresso.batch_auth_lookback_window, Some(42));
         assert!(cfg.is_batch_auth_enabled());
         assert!(cfg.is_espresso_active(1234));
         assert!(!cfg.is_espresso_active(1233));
-        assert_eq!(cfg.batch_auth_lookback_window(), 42);
     }
 }

--- a/crates/kona/genesis/src/rollup.rs
+++ b/crates/kona/genesis/src/rollup.rs
@@ -1,15 +1,183 @@
 //! Rollup Config Types
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_op_hardforks::{OpHardfork, OpHardforks};
+use alloy_primitives::Address;
 use kona_genesis::RollupConfig;
+
+/// The default batch-auth lookback window, in L1 blocks.
+///
+/// The scan covers the batch's L1 origin block plus this many ancestor blocks — i.e. an
+/// inclusive range of `window + 1` blocks (see `celo_derive::collect_authenticated_batches`).
+/// Roughly 20 minutes of ancestry on Ethereum mainnet (12s blocks).
+///
+/// This parameter affects derivation consensus, so it must remain a single value across all
+/// participants for the lifetime of the chain, and must match the op-node batcher/verifier. It is
+/// configured per-chain via `rollup.json` rather than as a per-operator CLI flag.
+///
+/// The constant is duplicated here (rather than added to upstream `kona-genesis`) because
+/// celo-kona wraps upstream kona instead of patching it at source.
+pub const DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW: u64 = 100;
+
+/// Celo-specific Espresso batch-authentication configuration.
+///
+/// These fields live on [`CeloRollupConfig`] rather than on upstream
+/// [`kona_genesis::RollupConfig`] / [`kona_genesis::HardForkConfig`], because celo-kona consumes
+/// upstream kona unmodified. They are parsed from the same `rollup.json` document that produces
+/// the wrapped [`RollupConfig`].
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CeloEspressoConfig {
+    /// Activation timestamp (L2) for the Espresso event-only batch authorization hardfork.
+    ///
+    /// Pre-fork the derivation pipeline runs vanilla OP Stack semantics (sender-based
+    /// authorization, no `BatchAuthenticator` event lookup). Post-fork batches must be
+    /// authenticated by `BatchInfoAuthenticated` events; sender-based fallback is rejected.
+    ///
+    /// The per-L1-block decision in the data source is gated on the L1 origin time of the block
+    /// being scanned, mirroring the upstream `ecotoneTime` precedent.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub espresso_time: Option<u64>,
+    /// Address of the `BatchAuthenticator` contract on L1. When set, enables event-based batch
+    /// authentication instead of sender verification. The derivation pipeline scans L1 receipts
+    /// for `BatchInfoAuthenticated` events emitted by this contract in a lookback window to
+    /// authenticate batches.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub batch_authenticator_address: Option<Address>,
+    /// Number of L1 blocks before the batch submission to scan for a `BatchInfoAuthenticated`
+    /// event. When `None`, defaults to [`DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW`] via
+    /// [`CeloRollupConfig::batch_auth_lookback_window`].
+    ///
+    /// This must remain a single value across all participants for the chain's lifetime, so it
+    /// is configured per-chain in `rollup.json` rather than via a CLI flag.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub batch_auth_lookback_window: Option<u64>,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::Deref, derive_more::DerefMut)]
 // #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 /// CeloRollupConfig is thin wrapper around RollupConfig that ensures that deserialization can
 /// handle config containing the cel2_time field.
-pub struct CeloRollupConfig(pub RollupConfig);
+///
+/// It additionally carries Celo-specific Espresso batch-authentication settings
+/// ([`CeloEspressoConfig`]) which have no home on the upstream [`RollupConfig`].
+pub struct CeloRollupConfig {
+    /// The wrapped upstream OP Stack rollup config. `Deref`/`DerefMut` target.
+    #[deref]
+    #[deref_mut]
+    pub op_rollup_config: RollupConfig,
+    /// Celo-specific Espresso batch-authentication settings parsed from the same `rollup.json`.
+    pub espresso: CeloEspressoConfig,
+}
 
-// Custom deserialization that filters out cel2_time
+impl CeloRollupConfig {
+    /// Constructs a [`CeloRollupConfig`] from an upstream [`RollupConfig`] with default (disabled)
+    /// Espresso settings.
+    pub const fn new(op_rollup_config: RollupConfig) -> Self {
+        Self {
+            op_rollup_config,
+            espresso: CeloEspressoConfig {
+                espresso_time: None,
+                batch_authenticator_address: None,
+                batch_auth_lookback_window: None,
+            },
+        }
+    }
+
+    /// Returns true if event-based batch authentication is configured (a non-zero
+    /// `BatchAuthenticator` address is present).
+    ///
+    /// When enabled, the derivation pipeline scans L1 receipts for `BatchInfoAuthenticated`
+    /// events instead of relying on sender verification.
+    pub fn is_batch_auth_enabled(&self) -> bool {
+        self.espresso.batch_authenticator_address.is_some_and(|addr| !addr.is_zero())
+    }
+
+    /// Returns the configured batch auth lookback window, falling back to
+    /// [`DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW`] when unset.
+    pub fn batch_auth_lookback_window(&self) -> u64 {
+        self.espresso.batch_auth_lookback_window.unwrap_or(DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW)
+    }
+
+    /// Returns true if Espresso event-only batch authorization is active at the given L1 origin
+    /// timestamp.
+    ///
+    /// Pre-fork the derivation pipeline runs vanilla OP Stack semantics (sender-based
+    /// authorization, no `BatchAuthenticator` event lookup). Post-fork batches must be
+    /// authenticated by `BatchInfoAuthenticated` events; sender-based fallback is rejected.
+    ///
+    /// This is intentionally orthogonal to the chained OP Stack hardforks and to
+    /// [`Self::is_batch_auth_enabled`] (which only signals that a `BatchAuthenticator` contract
+    /// address is configured).
+    pub fn is_espresso_active(&self, timestamp: u64) -> bool {
+        self.espresso.espresso_time.is_some_and(|t| timestamp >= t)
+    }
+
+    /// Resolves the Espresso batch-authentication parameters into a validated bundle suitable for
+    /// the derivation data sources.
+    ///
+    /// Returns:
+    /// - `Ok(None)` when no `espresso_time` is configured (Espresso is off; the derivation pipeline
+    ///   runs vanilla OP Stack semantics). A `BatchAuthenticator` address without an
+    ///   `espresso_time` is treated as "not yet scheduled" and likewise yields `None`.
+    /// - `Ok(Some((authenticator_address, espresso_time, lookback_window)))` when both an
+    ///   `espresso_time` and a non-zero authenticator address are configured.
+    /// - `Err(MissingAuthenticatorAddress)` when `espresso_time` is set but no usable authenticator
+    ///   address is configured (missing or zero) — otherwise no batch could ever be authorized
+    ///   post-fork and derivation would silently stall at the fork boundary.
+    ///
+    /// The tuple bundles the three coupled parameters so downstream code cannot represent the
+    /// illegal "fork scheduled but no authenticator" state.
+    pub fn batch_auth_params(
+        &self,
+    ) -> Result<Option<(Address, u64, u64)>, CeloEspressoConfigError> {
+        let Some(espresso_time) = self.espresso.espresso_time else {
+            return Ok(None);
+        };
+        let authenticator_address = self
+            .espresso
+            .batch_authenticator_address
+            .filter(|addr| !addr.is_zero())
+            .ok_or(CeloEspressoConfigError::MissingAuthenticatorAddress)?;
+        Ok(Some((authenticator_address, espresso_time, self.batch_auth_lookback_window())))
+    }
+
+    /// Validates that the Espresso batch-authentication settings are internally consistent.
+    ///
+    /// Espresso activation (`espresso_time`) enables event-only batch authorization: post-fork a
+    /// batch is authorized solely by a `BatchInfoAuthenticated` event from the configured
+    /// `BatchAuthenticator`. If `espresso_time` is set but no usable authenticator address is
+    /// configured (missing or zero), there is no way for any batch to be authorized post-fork, so
+    /// derivation would silently stall at the fork boundary. Reject that combination up front so
+    /// the misconfiguration surfaces as a clear error instead of a stuck pipeline.
+    pub fn validate_espresso(&self) -> Result<(), CeloEspressoConfigError> {
+        self.batch_auth_params().map(|_| ())
+    }
+}
+
+/// Errors produced when validating the Celo Espresso batch-authentication configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
+pub enum CeloEspressoConfigError {
+    /// `espresso_time` is configured but no non-zero `batch_authenticator_address` is set, which
+    /// would make post-fork derivation reject every batch.
+    #[display(
+        "espresso_time is set but batch_authenticator_address is missing or zero; \
+         post-fork derivation would reject all batches"
+    )]
+    MissingAuthenticatorAddress,
+}
+
+impl core::error::Error for CeloEspressoConfigError {}
+
+impl From<RollupConfig> for CeloRollupConfig {
+    fn from(op_rollup_config: RollupConfig) -> Self {
+        Self::new(op_rollup_config)
+    }
+}
+
+// Custom deserialization that filters out cel2_time and the Celo Espresso fields before handing
+// the remainder to the upstream `RollupConfig` deserializer (which would reject unknown keys
+// otherwise), then re-attaches the Espresso settings.
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for CeloRollupConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -22,10 +190,47 @@ impl<'de> serde::Deserialize<'de> for CeloRollupConfig {
 
         json_obj.remove("cel2_time");
 
+        // Extract the Espresso fields (if present) before deserializing the upstream config,
+        // since `RollupConfig` does not know about them.
+        let espresso = CeloEspressoConfig {
+            espresso_time: take_u64(&mut json_obj, "espresso_time")
+                .map_err(serde::de::Error::custom)?,
+            batch_authenticator_address: take_address(&mut json_obj, "batch_authenticator_address")
+                .map_err(serde::de::Error::custom)?,
+            batch_auth_lookback_window: take_u64(&mut json_obj, "batch_auth_lookback_window")
+                .map_err(serde::de::Error::custom)?,
+        };
+
         let op_rollup_config = RollupConfig::deserialize(serde_json::Value::Object(json_obj))
             .map_err(serde::de::Error::custom)?;
 
-        Ok(Self(op_rollup_config))
+        Ok(Self { op_rollup_config, espresso })
+    }
+}
+
+#[cfg(feature = "serde")]
+fn take_u64(
+    obj: &mut serde_json::Map<alloc::string::String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<u64>, alloc::string::String> {
+    match obj.remove(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(v) => {
+            serde_json::from_value(v).map(Some).map_err(|e| alloc::format!("invalid `{key}`: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+fn take_address(
+    obj: &mut serde_json::Map<alloc::string::String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<Address>, alloc::string::String> {
+    match obj.remove(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(v) => {
+            serde_json::from_value(v).map(Some).map_err(|e| alloc::format!("invalid `{key}`: {e}"))
+        }
     }
 }
 
@@ -33,7 +238,7 @@ impl<'de> serde::Deserialize<'de> for CeloRollupConfig {
 // we need to add this minimal wrapper to have CeloRollupConfig satisfy OpHardforks trait bounds.
 impl OpHardforks for CeloRollupConfig {
     fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
-        self.0.op_fork_activation(fork)
+        self.op_rollup_config.op_fork_activation(fork)
     }
 }
 
@@ -42,7 +247,7 @@ impl OpHardforks for CeloRollupConfig {
 // EthereumHardforks trait bounds.
 impl EthereumHardforks for CeloRollupConfig {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        self.0.ethereum_fork_activation(fork)
+        self.op_rollup_config.ethereum_fork_activation(fork)
     }
 }
 
@@ -111,7 +316,7 @@ mod tests {
         }
         "#;
 
-        let expected = CeloRollupConfig(RollupConfig {
+        let expected = CeloRollupConfig::new(RollupConfig {
             genesis: ChainGenesis {
                 l1: BlockNumHash {
                     hash: b256!("481724ee99b1f4cb71d826e2ec5a37265f460e9b112315665c977f4050b0af54"),
@@ -170,5 +375,157 @@ mod tests {
 
         let deserialized: CeloRollupConfig = serde_json::from_str(raw).unwrap();
         assert_eq!(deserialized, expected);
+        // No Espresso fields in this config => defaults (disabled).
+        assert_eq!(deserialized.espresso, CeloEspressoConfig::default());
+        assert!(!deserialized.is_batch_auth_enabled());
+        assert!(!deserialized.is_espresso_active(u64::MAX));
+        assert_eq!(deserialized.batch_auth_lookback_window(), DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW);
+    }
+
+    #[test]
+    fn test_is_espresso_active() {
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        // Unset: never active.
+        assert!(!cfg.is_espresso_active(0));
+        assert!(!cfg.is_espresso_active(u64::MAX));
+        // Set: boundary semantics match the OP Stack forks.
+        cfg.espresso.espresso_time = Some(100);
+        assert!(!cfg.is_espresso_active(99));
+        assert!(cfg.is_espresso_active(100));
+        assert!(cfg.is_espresso_active(101));
+    }
+
+    #[test]
+    fn test_batch_auth_helpers() {
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        assert!(!cfg.is_batch_auth_enabled());
+        assert_eq!(cfg.batch_auth_lookback_window(), DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW);
+
+        // Zero address does not enable batch auth.
+        cfg.espresso.batch_authenticator_address = Some(Address::ZERO);
+        assert!(!cfg.is_batch_auth_enabled());
+
+        cfg.espresso.batch_authenticator_address =
+            Some(address!("1234567890123456789012345678901234567890"));
+        assert!(cfg.is_batch_auth_enabled());
+
+        cfg.espresso.batch_auth_lookback_window = Some(7);
+        assert_eq!(cfg.batch_auth_lookback_window(), 7);
+    }
+
+    #[test]
+    fn test_validate_espresso() {
+        // Nothing configured: valid (Espresso disabled).
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        assert_eq!(cfg.validate_espresso(), Ok(()));
+
+        // espresso_time set without an authenticator: invalid (would stall derivation).
+        cfg.espresso.espresso_time = Some(100);
+        assert_eq!(
+            cfg.validate_espresso(),
+            Err(CeloEspressoConfigError::MissingAuthenticatorAddress)
+        );
+
+        // Zero authenticator address is treated as unset: still invalid.
+        cfg.espresso.batch_authenticator_address = Some(Address::ZERO);
+        assert_eq!(
+            cfg.validate_espresso(),
+            Err(CeloEspressoConfigError::MissingAuthenticatorAddress)
+        );
+
+        // espresso_time + valid authenticator: valid.
+        cfg.espresso.batch_authenticator_address =
+            Some(address!("1234567890123456789012345678901234567890"));
+        assert_eq!(cfg.validate_espresso(), Ok(()));
+
+        // Authenticator configured without espresso_time is allowed (fork not yet active).
+        let mut cfg2 = CeloRollupConfig::new(RollupConfig::default());
+        cfg2.espresso.batch_authenticator_address =
+            Some(address!("1234567890123456789012345678901234567890"));
+        assert_eq!(cfg2.validate_espresso(), Ok(()));
+    }
+
+    #[test]
+    fn test_batch_auth_params() {
+        let auth = address!("1234567890123456789012345678901234567890");
+
+        // No espresso_time: Espresso off => None (even if an authenticator is set).
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        assert_eq!(cfg.batch_auth_params(), Ok(None));
+        cfg.espresso.batch_authenticator_address = Some(auth);
+        assert_eq!(cfg.batch_auth_params(), Ok(None));
+
+        // espresso_time + valid authenticator => bundled params with default window.
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        cfg.espresso.espresso_time = Some(42);
+        cfg.espresso.batch_authenticator_address = Some(auth);
+        assert_eq!(
+            cfg.batch_auth_params(),
+            Ok(Some((auth, 42, DEFAULT_BATCH_AUTH_LOOKBACK_WINDOW)))
+        );
+
+        // Explicit lookback window is threaded through.
+        cfg.espresso.batch_auth_lookback_window = Some(7);
+        assert_eq!(cfg.batch_auth_params(), Ok(Some((auth, 42, 7))));
+
+        // espresso_time without authenticator (or zero) => hard error.
+        let mut cfg = CeloRollupConfig::new(RollupConfig::default());
+        cfg.espresso.espresso_time = Some(42);
+        assert_eq!(
+            cfg.batch_auth_params(),
+            Err(CeloEspressoConfigError::MissingAuthenticatorAddress)
+        );
+        cfg.espresso.batch_authenticator_address = Some(Address::ZERO);
+        assert_eq!(
+            cfg.batch_auth_params(),
+            Err(CeloEspressoConfigError::MissingAuthenticatorAddress)
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_deserialize_espresso_fields() {
+        let raw: &str = r#"
+        {
+          "genesis": {
+            "l1": { "hash": "0x481724ee99b1f4cb71d826e2ec5a37265f460e9b112315665c977f4050b0af54", "number": 10 },
+            "l2": { "hash": "0x88aedfbf7dea6bfa2c4ff315784ad1a7f145d8f650969359c003bbed68c87631", "number": 0 },
+            "l2_time": 1725557164,
+            "system_config": {
+              "batcherAddr": "0xc81f87a644b41e49b3221f41251f15c6cb00ce03",
+              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              "gasLimit": 30000000
+            }
+          },
+          "block_time": 2,
+          "max_sequencer_drift": 600,
+          "seq_window_size": 3600,
+          "channel_timeout": 300,
+          "l1_chain_id": 3151908,
+          "l2_chain_id": 1337,
+          "regolith_time": 0,
+          "cel2_time": 0,
+          "espresso_time": 1234,
+          "batch_authenticator_address": "0x00000000000000000000000000000000000000aa",
+          "batch_auth_lookback_window": 42,
+          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
+          "deposit_contract_address": "0x08073dc48dde578137b8af042bcbc1c2491f1eb2",
+          "l1_system_config_address": "0x94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710",
+          "chain_op_config": { "eip1559Elasticity": 6, "eip1559Denominator": 50, "eip1559DenominatorCanyon": 250 }
+        }
+        "#;
+
+        let cfg: CeloRollupConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(cfg.espresso.espresso_time, Some(1234));
+        assert_eq!(
+            cfg.espresso.batch_authenticator_address,
+            Some(address!("00000000000000000000000000000000000000aa"))
+        );
+        assert_eq!(cfg.espresso.batch_auth_lookback_window, Some(42));
+        assert!(cfg.is_batch_auth_enabled());
+        assert!(cfg.is_espresso_active(1234));
+        assert!(!cfg.is_espresso_active(1233));
+        assert_eq!(cfg.batch_auth_lookback_window(), 42);
     }
 }

--- a/crates/kona/proof/src/boot.rs
+++ b/crates/kona/proof/src/boot.rs
@@ -4,6 +4,7 @@
 //! remove `CeloBootInfo`.
 
 use alloy_primitives::B256;
+use celo_genesis::{CeloEspressoConfig, CeloRollupConfig};
 use celo_registry::ROLLUP_CONFIGS;
 use kona_preimage::{PreimageKey, PreimageOracleClient};
 use kona_proof::{
@@ -23,6 +24,13 @@ use tracing::warn;
 pub struct CeloBootInfo {
     /// The boot information for OP.
     pub op_boot_info: BootInfo,
+    /// Celo-specific Espresso batch-authentication settings.
+    ///
+    /// Sourced from the [`CeloRollupConfig`] (registry entry or the rollup config deserialized
+    /// from the preimage oracle). The OP [`BootInfo`] carries only the upstream `RollupConfig`,
+    /// which has no place for these fields, so they are tracked alongside it here.
+    #[serde(default)]
+    pub espresso: CeloEspressoConfig,
 }
 
 impl CeloBootInfo {
@@ -77,8 +85,10 @@ impl CeloBootInfo {
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
-        let rollup_config = if let Some(config) = ROLLUP_CONFIGS.get(&chain_id) {
-            config.0.clone()
+        let celo_rollup_config: CeloRollupConfig = if let Some(config) =
+            ROLLUP_CONFIGS.get(&chain_id)
+        {
+            config.clone()
         } else {
             warn!(
                 target: "boot_loader",
@@ -91,6 +101,14 @@ impl CeloBootInfo {
                 .map_err(OracleProviderError::Preimage)?;
             serde_json::from_slice(&ser_cfg).map_err(OracleProviderError::Serde)?
         };
+        // Reject internally inconsistent Espresso settings (e.g. `espresso_time` set without a
+        // `BatchAuthenticator` address) up front, so a misconfiguration fails fast here instead of
+        // silently stalling derivation at the fork boundary.
+        celo_rollup_config.validate_espresso().map_err(|e| {
+            OracleProviderError::Serde(<serde_json::Error as serde::de::Error>::custom(e))
+        })?;
+        let espresso = celo_rollup_config.espresso;
+        let rollup_config = celo_rollup_config.op_rollup_config;
 
         // Attempt to load the L1 config from the L1 chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
@@ -140,6 +158,7 @@ impl CeloBootInfo {
                 rollup_config,
                 l1_config,
             },
+            espresso,
         })
     }
 }

--- a/crates/kona/registry/src/superchain.rs
+++ b/crates/kona/registry/src/superchain.rs
@@ -74,7 +74,7 @@ impl Registry {
                     rollup.da_challenge_address = None;
                 }
                 // Wrap RollupConfig to CeloRollupConfig
-                let celo_rollup = CeloRollupConfig(rollup);
+                let celo_rollup = CeloRollupConfig::new(rollup);
                 rollup_configs.insert(chain_config.chain_id, celo_rollup);
                 op_chains.insert(chain_config.chain_id, chain_config);
             }
@@ -104,15 +104,15 @@ mod tests {
         // kona fork patched the constant globally. The chainList JSON value for Sepolia/Chaos
         // (600) describes the pre-Fjord drift; post-Fjord, the chain ran with 2892.
         let mainnet = registry.rollup_configs.get(&CELO_MAINNET_CHAIN_ID).unwrap();
-        assert_eq!(mainnet.0.max_sequencer_drift, 2892);
-        assert_eq!(mainnet.0.fjord_max_sequencer_drift, 2892);
+        assert_eq!(mainnet.max_sequencer_drift, 2892);
+        assert_eq!(mainnet.fjord_max_sequencer_drift, 2892);
 
         let sepolia = registry.rollup_configs.get(&CELO_SEPOLIA_CHAIN_ID).unwrap();
-        assert_eq!(sepolia.0.max_sequencer_drift, 600);
-        assert_eq!(sepolia.0.fjord_max_sequencer_drift, 2892);
+        assert_eq!(sepolia.max_sequencer_drift, 600);
+        assert_eq!(sepolia.fjord_max_sequencer_drift, 2892);
 
         let chaos = registry.rollup_configs.get(&CELO_CHAOS_CHAIN_ID).unwrap();
-        assert_eq!(chaos.0.max_sequencer_drift, 600);
-        assert_eq!(chaos.0.fjord_max_sequencer_drift, 2892);
+        assert_eq!(chaos.max_sequencer_drift, 600);
+        assert_eq!(chaos.fjord_max_sequencer_drift, 2892);
     }
 }


### PR DESCRIPTION
Rust counterpart of https://github.com/celo-org/optimism/pull/445
Most edits are direct copies of kona types for visibility reasons, actually new code is `crates/kona/derive/src/batch_auth.rs`, authentication path added to `crates/kona/derive/src/blobs.rs` and config added to `crates/kona/genesis/src/rollup.rs`
Needs a [hokulea change](https://github.com/celo-org/hokulea/pull/2) to allow EigenDA data source to use the non-standard L1 data source introduce here  