### PR TITLE
fix(celo-reth): migrate history indices to RocksDB in celo-migrate-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,6 +3030,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
+ "arbitrary",
  "cfg-if",
  "crossbeam-utils",
  "hashbrown 0.14.5",
@@ -4091,6 +4092,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hashbag"
@@ -7093,6 +7100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain_hasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7255,6 +7271,16 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-arbitrary-interop"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
+dependencies = [
+ "arbitrary",
+ "proptest",
 ]
 
 [[package]]
@@ -7857,6 +7883,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
  "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
  "derive_more",
  "metrics",
  "parking_lot",
@@ -8033,12 +8061,14 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
+ "arbitrary",
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
+ "visibility",
 ]
 
 [[package]]
@@ -8131,6 +8161,7 @@ dependencies = [
  "libc",
  "metrics",
  "page_size",
+ "parking_lot",
  "quanta",
  "reth-db-api",
  "reth-fs-util",
@@ -8143,6 +8174,7 @@ dependencies = [
  "rustc-hash",
  "strum",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -8154,11 +8186,13 @@ source = "git+https://github.com/paradigmxyz/reth?rev=88505c7fcbfdebfd3b56d88c86
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
+ "arbitrary",
  "arrayvec",
  "bytes",
  "derive_more",
  "metrics",
  "modular-bitfield",
+ "proptest",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
@@ -8208,6 +8242,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=88505c7fcbfdebfd3b56d88c86
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
+ "arbitrary",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -9842,12 +9877,15 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-trie",
+ "arbitrary",
  "byteorder",
  "bytes",
  "dashmap",
  "derive_more",
  "modular-bitfield",
  "once_cell",
+ "proptest",
+ "proptest-arbitrary-interop",
  "quanta",
  "rayon",
  "reth-codecs",
@@ -9881,6 +9919,7 @@ dependencies = [
  "reth-db",
  "reth-db-api",
  "reth-errors",
+ "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
  "reth-fs-util",
@@ -9897,8 +9936,10 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm-database",
+ "revm-state",
  "rocksdb",
  "strum",
+ "tokio",
  "tracing",
 ]
 
@@ -9937,6 +9978,7 @@ version = "2.2.0"
 source = "git+https://github.com/paradigmxyz/reth?rev=88505c7fcbfdebfd3b56d88c86b62e950043c6c4#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
  "derive_more",
  "modular-bitfield",
  "reth-codecs",
@@ -10384,6 +10426,7 @@ version = "2.2.0"
 source = "git+https://github.com/paradigmxyz/reth?rev=88505c7fcbfdebfd3b56d88c86b62e950043c6c4#88505c7fcbfdebfd3b56d88c86b62e950043c6c4"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -10600,6 +10643,7 @@ dependencies = [
  "reth-trie-sparse",
  "revm-database",
  "tracing",
+ "triehash",
 ]
 
 [[package]]
@@ -10613,11 +10657,14 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
  "alloy-trie",
+ "arbitrary",
  "arrayvec",
  "bytes",
  "derive_more",
+ "hash-db",
  "itertools 0.14.0",
  "nybbles",
+ "plain_hasher",
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
@@ -12736,6 +12783,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triehash"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13004,6 +13061,17 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/crates/celo-reth/Cargo.toml
+++ b/crates/celo-reth/Cargo.toml
@@ -134,6 +134,7 @@ zstd.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 proptest = "1.11"
 trybuild = "1"
+reth-provider = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = ["std"]

--- a/crates/celo-reth/src/celo_migrate_v2.rs
+++ b/crates/celo-reth/src/celo_migrate_v2.rs
@@ -813,4 +813,97 @@ mod tests {
             "a populated AccountsHistory must read as not cleared",
         );
     }
+
+    /// A multi-shard account must have *every* shard copied verbatim. The single-shard test above
+    /// would also pass under a broken `append_account_history_shard`-based copy — a single append
+    /// call never trips the once-per-address-per-batch rule — so it cannot guard the property the
+    /// `migrate_account_history` doc comment relies on. Seeding a closed shard plus the open
+    /// `u64::MAX` shard for one address pins the verbatim copy and would fail if a second shard's
+    /// write overwrote the first.
+    #[test]
+    fn migrate_account_history_copies_all_shards_of_multi_shard_address() {
+        let factory = create_test_provider_factory();
+        let address = Address::with_last_byte(0x42);
+
+        // Closed shard keyed by its last block, then the open shard keyed by u64::MAX.
+        let closed_key = ShardedKey::new(address, 1000u64);
+        let closed_blocks = [10u64, 500, 1000];
+        let open_key = ShardedKey::new(address, u64::MAX);
+        let open_blocks = [1001u64, 2000, 3000];
+
+        {
+            let provider_rw = factory.database_provider_rw().unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::AccountsHistory>(
+                    closed_key.clone(),
+                    tables::BlockNumberList::new(closed_blocks).unwrap(),
+                )
+                .unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::AccountsHistory>(
+                    open_key.clone(),
+                    tables::BlockNumberList::new(open_blocks).unwrap(),
+                )
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        CeloMigrateV2Command::migrate_account_history(&factory).unwrap();
+
+        // Shards are returned in ascending highest_block_number order: closed shard first.
+        let shards = factory.rocksdb_provider().account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 2, "both shards of the address must be copied");
+        assert_eq!(shards[0].0, closed_key);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), closed_blocks.to_vec());
+        assert_eq!(shards[1].0, open_key);
+        assert_eq!(shards[1].1.iter().collect::<Vec<_>>(), open_blocks.to_vec());
+    }
+
+    /// Storage-slot counterpart of
+    /// [`migrate_account_history_copies_all_shards_of_multi_shard_address`]: every shard of a
+    /// multi-shard `(address, slot)` must be copied verbatim.
+    #[test]
+    fn migrate_storage_history_copies_all_shards_of_multi_shard_key() {
+        use alloy_primitives::B256;
+        use reth_db_api::models::storage_sharded_key::StorageShardedKey;
+
+        let factory = create_test_provider_factory();
+        let address = Address::with_last_byte(0x42);
+        let slot = B256::with_last_byte(0x07);
+
+        let closed_key = StorageShardedKey::new(address, slot, 1000u64);
+        let closed_blocks = [11u64, 22, 1000];
+        let open_key = StorageShardedKey::new(address, slot, u64::MAX);
+        let open_blocks = [1001u64, 2002, 3003];
+
+        {
+            let provider_rw = factory.database_provider_rw().unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::StoragesHistory>(
+                    closed_key.clone(),
+                    tables::BlockNumberList::new(closed_blocks).unwrap(),
+                )
+                .unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::StoragesHistory>(
+                    open_key.clone(),
+                    tables::BlockNumberList::new(open_blocks).unwrap(),
+                )
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        CeloMigrateV2Command::migrate_storage_history(&factory).unwrap();
+
+        let shards = factory.rocksdb_provider().storage_history_shards(address, slot).unwrap();
+        assert_eq!(shards.len(), 2, "both shards of the (address, slot) must be copied");
+        assert_eq!(shards[0].0, closed_key);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), closed_blocks.to_vec());
+        assert_eq!(shards[1].0, open_key);
+        assert_eq!(shards[1].1.iter().collect::<Vec<_>>(), open_blocks.to_vec());
+    }
 }

--- a/crates/celo-reth/src/celo_migrate_v2.rs
+++ b/crates/celo-reth/src/celo_migrate_v2.rs
@@ -34,8 +34,8 @@ use reth_node_core::args::{DatabaseArgs, DatadirArgs, StaticFilesArgs};
 use reth_optimism_node::OpNode;
 use reth_provider::{
     DBProvider, DatabaseProviderFactory, MetadataProvider, MetadataWriter, ProviderFactory,
-    PruneCheckpointReader, StaticFileProviderFactory, StaticFileWriter, StorageSettings,
-    providers::ProviderNodeTypes,
+    PruneCheckpointReader, RocksDBProviderFactory, StaticFileProviderFactory, StaticFileWriter,
+    StorageSettings, providers::ProviderNodeTypes,
 };
 use reth_prune_types::PruneSegment;
 use reth_stages_types::StageId;
@@ -206,6 +206,20 @@ impl CeloMigrateV2Command {
         }
         info!(target: "reth::cli", "Storage settings updated to v2");
 
+        // === Phase 3b: Copy MDBX history indices → RocksDB ===
+        //
+        // Phase 4 below clears the MDBX `AccountsHistory` / `StoragesHistory` tables. In v2
+        // those indices are served from RocksDB, but nothing has ever copied the imported
+        // pre-migration history into RocksDB — the v2 write path only indexes blocks the node
+        // executes, and the upstream IndexHistory pipeline stages we skip (dummy blocks have no
+        // bodies) never run. We must move them here, after the v2 flip so RocksDB is the active
+        // store and before the clear removes the only copy. Without this the history index is
+        // empty, so every historical-state read past the in-memory canonical buffer misses and
+        // reads as an empty account — including the FeeCurrencyDirectory, which surfaces as
+        // "fee currency not registered" and stalls the chain (#192).
+        Self::migrate_account_history(&provider_factory)?;
+        Self::migrate_storage_history(&provider_factory)?;
+
         // === Phase 4: Clear MDBX tables superseded by the v2 layout ===
         //
         // After the flip these MDBX tables are never read in v2 (changesets come from static
@@ -374,6 +388,66 @@ impl CeloMigrateV2Command {
         writer.commit()?;
 
         info!(target: "reth::cli", count, "StorageChangeSets migrated");
+        Ok(())
+    }
+
+    /// Copy the MDBX `AccountsHistory` index into the v2 RocksDB store.
+    ///
+    /// MDBX and RocksDB use identical `ShardedKey` / `BlockNumberList` encoding and the same
+    /// per-shard chunking, so every `(ShardedKey, BlockNumberList)` pair is copied verbatim —
+    /// no regrouping by address or re-sharding. (`append_account_history_shard` is deliberately
+    /// avoided: it reads existing shards from committed state and must be called at most once per
+    /// address per batch, which a verbatim shard-by-shard walk would violate for any
+    /// multi-shard address.) The batch auto-commits on a size threshold so a full-mainnet
+    /// history table does not accumulate in memory.
+    fn migrate_account_history<N: ProviderNodeTypes>(
+        factory: &ProviderFactory<N>,
+    ) -> eyre::Result<()> {
+        info!(target: "reth::cli", "Migrating AccountsHistory index → RocksDB");
+        let provider_rw = factory.database_provider_rw()?;
+
+        let count = provider_rw.with_rocksdb_batch_auto_commit(|mut batch| {
+            let mut cursor = provider_rw.tx_ref().cursor_read::<tables::AccountsHistory>()?;
+            let mut count = 0u64;
+            for entry in cursor.walk(None)? {
+                let (key, value) = entry?;
+                batch.put::<tables::AccountsHistory>(key, &value)?;
+                count += 1;
+            }
+            Ok((count, Some(batch.into_inner())))
+        })?;
+
+        provider_rw.commit()?;
+
+        info!(target: "reth::cli", count, "AccountsHistory shards migrated");
+        Ok(())
+    }
+
+    /// Copy the MDBX `StoragesHistory` index into the v2 RocksDB store.
+    ///
+    /// Storage-slot counterpart of [`Self::migrate_account_history`]; see its docs for why the
+    /// copy is verbatim (identical `StorageShardedKey` / `BlockNumberList` encoding and sharding)
+    /// and why the batch auto-commits.
+    fn migrate_storage_history<N: ProviderNodeTypes>(
+        factory: &ProviderFactory<N>,
+    ) -> eyre::Result<()> {
+        info!(target: "reth::cli", "Migrating StoragesHistory index → RocksDB");
+        let provider_rw = factory.database_provider_rw()?;
+
+        let count = provider_rw.with_rocksdb_batch_auto_commit(|mut batch| {
+            let mut cursor = provider_rw.tx_ref().cursor_read::<tables::StoragesHistory>()?;
+            let mut count = 0u64;
+            for entry in cursor.walk(None)? {
+                let (key, value) = entry?;
+                batch.put::<tables::StoragesHistory>(key, &value)?;
+                count += 1;
+            }
+            Ok((count, Some(batch.into_inner())))
+        })?;
+
+        provider_rw.commit()?;
+
+        info!(target: "reth::cli", count, "StoragesHistory shards migrated");
         Ok(())
     }
 
@@ -577,6 +651,9 @@ impl CeloMigrateV2Command {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::Address;
+    use reth_db_api::models::ShardedKey;
+    use reth_provider::{RocksDBProviderFactory, test_utils::create_test_provider_factory};
 
     #[test]
     fn parse_minimal_cli() {
@@ -584,5 +661,85 @@ mod tests {
         let cmd =
             CeloMigrateV2Command::parse_from(["celo-migrate-v2", "--datadir", "/tmp/celo-data"]);
         assert!(cmd.config.is_none());
+    }
+
+    /// `migrate_account_history` must copy each MDBX `AccountsHistory` shard verbatim into
+    /// RocksDB. This is the #192 fix: without it the v2 datadir's history index is empty and
+    /// every historical state read past the in-memory buffer misses.
+    #[test]
+    fn migrate_account_history_copies_mdbx_shard_to_rocksdb() {
+        let factory = create_test_provider_factory();
+        let address = Address::with_last_byte(0x42);
+        let blocks = [10u64, 20, 30];
+        let key = ShardedKey::new(address, u64::MAX);
+
+        // Seed one MDBX AccountsHistory shard for `address`.
+        {
+            let provider_rw = factory.database_provider_rw().unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::AccountsHistory>(
+                    key.clone(),
+                    tables::BlockNumberList::new(blocks).unwrap(),
+                )
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        // Precondition: RocksDB has nothing for this address yet, so a passing postcondition
+        // can only come from the migration actually writing the shard.
+        assert!(
+            factory.rocksdb_provider().account_history_shards(address).unwrap().is_empty(),
+            "precondition: RocksDB account history index must start empty",
+        );
+
+        CeloMigrateV2Command::migrate_account_history(&factory).unwrap();
+
+        // The shard now exists in RocksDB with the same key and block list as the MDBX source.
+        let shards = factory.rocksdb_provider().account_history_shards(address).unwrap();
+        assert_eq!(shards.len(), 1, "expected exactly one migrated shard");
+        assert_eq!(shards[0].0, key);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), blocks.to_vec());
+    }
+
+    /// `migrate_storage_history` must copy each MDBX `StoragesHistory` shard verbatim into
+    /// RocksDB, the storage-slot counterpart of the account-history copy above (#192).
+    #[test]
+    fn migrate_storage_history_copies_mdbx_shard_to_rocksdb() {
+        use alloy_primitives::B256;
+        use reth_db_api::models::storage_sharded_key::StorageShardedKey;
+
+        let factory = create_test_provider_factory();
+        let address = Address::with_last_byte(0x42);
+        let slot = B256::with_last_byte(0x07);
+        let blocks = [11u64, 22, 33];
+        let key = StorageShardedKey::new(address, slot, u64::MAX);
+
+        // Seed one MDBX StoragesHistory shard for `(address, slot)`.
+        {
+            let provider_rw = factory.database_provider_rw().unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::StoragesHistory>(
+                    key.clone(),
+                    tables::BlockNumberList::new(blocks).unwrap(),
+                )
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        // Precondition: RocksDB storage history is empty for this key.
+        assert!(
+            factory.rocksdb_provider().storage_history_shards(address, slot).unwrap().is_empty(),
+            "precondition: RocksDB storage history index must start empty",
+        );
+
+        CeloMigrateV2Command::migrate_storage_history(&factory).unwrap();
+
+        // The shard now exists in RocksDB with the same key and block list as the MDBX source.
+        let shards = factory.rocksdb_provider().storage_history_shards(address, slot).unwrap();
+        assert_eq!(shards.len(), 1, "expected exactly one migrated shard");
+        assert_eq!(shards[0].0, key);
+        assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), blocks.to_vec());
     }
 }

--- a/crates/celo-reth/src/celo_migrate_v2.rs
+++ b/crates/celo-reth/src/celo_migrate_v2.rs
@@ -141,8 +141,28 @@ impl CeloMigrateV2Command {
         let current_settings = provider.storage_settings()?;
 
         if current_settings.is_some_and(|s| s.is_v2()) {
-            info!(target: "reth::cli", "Storage is already v2, nothing to do");
-            return Ok(());
+            // A v2 datadir is a genuine no-op ONLY if a prior migration ran to completion. Phase 4
+            // empties the MDBX `AccountsHistory` / `StoragesHistory` tables, so on a finished
+            // migration — and on a natively-synced v2 node, which never writes history to MDBX —
+            // both read empty. If either is still populated, a previous run crashed after the
+            // Phase 3 v2 flip but before the Phase 4 clear, leaving the RocksDB v2 history index
+            // incomplete. We must NOT silently report success and deliberately do NOT resume a
+            // partial migration — fail loudly so the operator re-imports a clean v1
+            // datadir.
+            drop(provider);
+            if Self::v2_history_tables_cleared(&provider_factory)? {
+                info!(target: "reth::cli", "Storage is already v2, nothing to do");
+                return Ok(());
+            }
+            eyre::bail!(
+                "Datadir is in a partially-migrated v2 state: StorageSettings is v2 but the MDBX \
+                 AccountsHistory/StoragesHistory tables are still populated, which means a \
+                 previous celo-migrate-v2 run crashed after flipping to v2 (Phase 3) but before \
+                 clearing the MDBX history (Phase 4). The RocksDB v2 history index is therefore \
+                 incomplete, so the node wouldn't serve historical state fetch once it syncs past \
+                 the in-memory canonical buffer. celo-migrate-v2 cannot resume a partial migration: \
+                 re-run import-celo-state to rebuild a clean v1 datadir, then run celo-migrate-v2 again."
+            );
         }
 
         let tip =
@@ -264,6 +284,22 @@ impl CeloMigrateV2Command {
              rebuild is required.",
         );
         Ok(())
+    }
+
+    /// Whether a v2 datadir's MDBX history tables have already been cleared (i.e. Phase 4 ran).
+    ///
+    /// A completed migration empties `AccountsHistory` / `StoragesHistory` in MDBX, and a
+    /// natively-synced v2 node never writes history to MDBX, so for both the tables read empty.
+    /// If either is still populated, a previous `celo-migrate-v2` run crashed after the Phase 3
+    /// v2 flip but before the Phase 4 clear, leaving the RocksDB v2 history index incomplete; the
+    /// Phase 0 guard uses this to fail loudly instead of silently reporting success.
+    fn v2_history_tables_cleared<N: ProviderNodeTypes>(
+        factory: &ProviderFactory<N>,
+    ) -> eyre::Result<bool> {
+        let provider = factory.provider()?;
+        let mut accounts = provider.tx_ref().cursor_read::<tables::AccountsHistory>()?;
+        let mut storages = provider.tx_ref().cursor_read::<tables::StoragesHistory>()?;
+        Ok(accounts.first()?.is_none() && storages.first()?.is_none())
     }
 
     // The following helpers are adapted from the upstream private associated functions on
@@ -741,5 +777,40 @@ mod tests {
         assert_eq!(shards.len(), 1, "expected exactly one migrated shard");
         assert_eq!(shards[0].0, key);
         assert_eq!(shards[0].1.iter().collect::<Vec<_>>(), blocks.to_vec());
+    }
+
+    /// A v2 datadir whose MDBX history tables are still populated is a partially-migrated datadir
+    /// — a previous run crashed between the Phase 3 v2 flip and the Phase 4 history clear. The
+    /// Phase 0 guard relies on this check to fail loudly rather than silently report "nothing to
+    /// do" on an incomplete datadir that would later wedge with #192.
+    #[test]
+    fn v2_history_tables_cleared_detects_partial_migration() {
+        let factory = create_test_provider_factory();
+
+        // A fresh datadir has empty history tables → reads as cleared (a legitimate no-op).
+        assert!(
+            CeloMigrateV2Command::v2_history_tables_cleared(&factory).unwrap(),
+            "empty AccountsHistory/StoragesHistory must read as cleared",
+        );
+
+        // Seed one AccountsHistory shard, mimicking a crash after the v2 flip but before Phase 4.
+        {
+            let provider_rw = factory.database_provider_rw().unwrap();
+            provider_rw
+                .tx_ref()
+                .put::<tables::AccountsHistory>(
+                    ShardedKey::new(Address::with_last_byte(0x42), u64::MAX),
+                    tables::BlockNumberList::new([1u64]).unwrap(),
+                )
+                .unwrap();
+            provider_rw.commit().unwrap();
+        }
+
+        // A populated history table must read as NOT cleared so the guard bails instead of
+        // silently exiting.
+        assert!(
+            !CeloMigrateV2Command::v2_history_tables_cleared(&factory).unwrap(),
+            "a populated AccountsHistory must read as not cleared",
+        );
     }
 }


### PR DESCRIPTION
## Summary

`celo-migrate-v2` clears the MDBX `AccountsHistory` / `StoragesHistory` tables in Phase 4 — the history index for the imported migration-point state — but no phase copies them into the v2 RocksDB store first. Forward sync does index history into RocksDB for the blocks it executes, but only for accounts whose state *changes* after the migration point. Any account left unchanged since the migration — including stable contracts such as the `FeeCurrencyDirectory` — keeps its sole history shard at the migration point, so once Phase 4 deletes it the shard is never recreated.

On an archive node a missing history shard does not fall back to plain state — the lookup returns `NotYetWritten` → `None` → an empty account. During CIP-64 execution the `FeeCurrencyDirectory` parent-state read, when it falls outside the in-memory canonical buffer, then reads empty → "fee currency not registered", the block is rejected on a receipt-root mismatch, and the chain stalls (#192). Plain state in MDBX is correct; only the migration-point history index is lost.

## What changed

A new **Phase 3b** copies `AccountsHistory` and `StoragesHistory` verbatim from MDBX into RocksDB, wired after the v2 flip (so RocksDB is the active store) and before the table clear (so the copy runs while the source still exists). `migrate_account_history` and `migrate_storage_history` cursor-walk each MDBX table and copy every `(ShardedKey, BlockNumberList)` pair as-is through `RocksDBBatch::put` inside `with_rocksdb_batch_auto_commit`, which auto-commits on a size threshold to bound memory on a full-mainnet history table.

The copy is verbatim because MDBX and RocksDB share identical `ShardedKey` / `BlockNumberList` encoding and per-shard chunking. `put` is used rather than `append_account_history_shard`: the append helper reads existing shards from committed state and is contract-bound to "at most once per address per batch", so a shard-by-shard walk would call it repeatedly for a multi-shard address and the later call would overwrite the earlier shard. `TransactionHashNumbers` needs no copy — the imported range has no transactions.

## Testing

Implemented test-first. Added `reth-provider`'s `test-utils` as a dev-dependency and two fixture tests on `create_test_provider_factory()` (which sets up MDBX + RocksDB + static files): seed an MDBX history shard, assert the RocksDB index is empty, run the migration, then assert the RocksDB shard matches the source. `just test` passes 287/287 including both new tests.

## Validation (live archive nodes)

Direct measurement on the affected fsn-0 / fsn-1 archive nodes confirms this is the complete fix. A RocksDB key count (secondary mode) shows the forward-synced range *is* fully indexed — `AccountsHistory` 41.5M keys, `StoragesHistory` 164M keys, `highest_block` spanning 31,058,500..69,012,784 — with **zero shards at or below the migration block**, so only the migration-point history is missing. Synced-range reads are served correctly at both the account and storage level — a recently-active EOA's nonce, and a storage slot from a guaranteed synced-range shard (correct, differing per-block values at H vs H-1), both read correctly beyond the in-memory buffer — so there is no read-path bug and no re-index is needed; the empty reads are exactly the accounts whose sole shard was the deleted migration-point one. A genesis-v2 node (no migration) serves all the same reads correctly, isolating the defect to the import + migrate-v2 flow.


Operational note: this fixes the migrate-v2 *process*. Datadirs already produced by the old `migrate-v2` have deleted their migration-point history and can't be repaired in place — they need rebuilding (re-`import-celo-state` + the fixed command).

## Notes

Stacked on #198 (`jcortejoso/celo-migrate-v2`); the base will need to retarget to `main` once #198 merges. The migration is not re-runnable across a crash mid-Phase-3b — a re-run hits the Phase 0 `is_v2()` guard and skips the remaining phases — but that is a pre-existing property shared by the existing Phase 4 (clear) and Phase 5 (compact), not introduced here.