### PR TITLE
feat(celo-reth): show celo-kona commit SHA in --version

### DIFF
--- a/.github/workflows/push-container-dev.yaml
+++ b/.github/workflows/push-container-dev.yaml
@@ -36,4 +36,4 @@ jobs:
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-kona/providers/github-by-repos
       concurrency-group: ${{ github.workflow }}-build-reth-${{ github.head_ref || github.ref }}
       build-args: |
-        CELO_KONA_GIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+        CELO_KONA_GIT_SHA=${{ github.sha }}

--- a/.github/workflows/push-container-dev.yaml
+++ b/.github/workflows/push-container-dev.yaml
@@ -35,3 +35,5 @@ jobs:
       service-account: celo-kona-gh@devopsre.iam.gserviceaccount.com
       workload-id-provider: projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-kona/providers/github-by-repos
       concurrency-group: ${{ github.workflow }}-build-reth-${{ github.head_ref || github.ref }}
+      build-args: |
+        CELO_KONA_GIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -17,6 +17,10 @@ on:
       concurrency-group:
         required: false
         type: string
+      build-args:
+        required: false
+        type: string
+        description: "Newline-separated list of build-time variables (KEY=VALUE) forwarded to the reusable workflow's `docker/build-push-action`."
 jobs:
   infer_image_metadata:
     name: Infer image tags from github ref type
@@ -63,4 +67,5 @@ jobs:
       context: .
       file: ${{ inputs.file }}
       tags: ${{ needs.infer_image_metadata.outputs.tags }}
+      build-args: ${{ inputs.build-args }}
       trivy-enabled: false

--- a/crates/celo-reth/Dockerfile
+++ b/crates/celo-reth/Dockerfile
@@ -9,6 +9,12 @@ RUN cargo chef prepare --recipe-path recipe.json --bin celo-reth
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 ARG BUILD_PROFILE=release
+# `.dockerignore` excludes `.git/`, so `crates/celo-reth/build.rs` cannot run
+# `git rev-parse HEAD` inside the build. CI must supply the SHA via `--build-arg`
+# (see `.github/workflows/push-container-dev.yaml`). Defaults to `unknown` so local
+# `docker build` without the arg still succeeds.
+ARG CELO_KONA_GIT_SHA=unknown
+ENV CELO_KONA_GIT_SHA=$CELO_KONA_GIT_SHA
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \

--- a/crates/celo-reth/Dockerfile
+++ b/crates/celo-reth/Dockerfile
@@ -9,17 +9,17 @@ RUN cargo chef prepare --recipe-path recipe.json --bin celo-reth
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 ARG BUILD_PROFILE=release
-# `.dockerignore` excludes `.git/`, so `crates/celo-reth/build.rs` cannot run
-# `git rev-parse HEAD` inside the build. CI must supply the SHA via `--build-arg`
-# (see `.github/workflows/push-container-dev.yaml`). Defaults to `unknown` so local
-# `docker build` without the arg still succeeds.
-ARG CELO_KONA_GIT_SHA=unknown
-ENV CELO_KONA_GIT_SHA=$CELO_KONA_GIT_SHA
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \
     cargo chef cook --profile $BUILD_PROFILE --recipe-path recipe.json --bin celo-reth
 COPY . .
+# SHA injected AFTER chef cook so dep-cache layer stays valid across PR commits.
+# `.dockerignore` excludes `.git/`, so `crates/celo-reth/build.rs` cannot run
+# `git rev-parse HEAD` in-container. CI passes the SHA via `--build-arg`; defaults
+# to `unknown` so local `docker build` without the arg still succeeds.
+ARG CELO_KONA_GIT_SHA=unknown
+ENV CELO_KONA_GIT_SHA=$CELO_KONA_GIT_SHA
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \

--- a/crates/celo-reth/build.rs
+++ b/crates/celo-reth/build.rs
@@ -2,16 +2,16 @@
 //! it alongside the upstream reth commit.
 //!
 //! Resolution order (first hit wins):
-//!   1. `CELO_KONA_GIT_SHA` env var passed by the build environment (Docker build-arg or
-//!      explicit shell override). This is the path Docker/CI builds use, because
-//!      `.dockerignore` excludes `.git/` and the in-container source has no git repo.
-//!   2. `git rev-parse HEAD` against the workspace. Works for local `cargo build`
-//!      invocations where `.git/` is on disk.
+//!   1. `CELO_KONA_GIT_SHA` env var passed by the build environment (Docker build-arg or explicit
+//!      shell override). This is the path Docker/CI builds use, because `.dockerignore` excludes
+//!      `.git/` and the in-container source has no git repo.
+//!   2. `git rev-parse HEAD` against the workspace. Works for local `cargo build` invocations where
+//!      `.git/` is on disk.
 //!   3. The literal string `"unknown"`, with a build warning.
 //!
 //! Output env vars (set via `cargo:rustc-env`):
-//!   * `CELO_KONA_GIT_SHA`       — 7-char short SHA (with optional `-dirty` suffix
-//!                                  when git reports uncommitted changes), e.g. `6ee40f2`.
+//!   * `CELO_KONA_GIT_SHA`       — 7-char short SHA (with optional `-dirty` suffix when git reports
+//!     uncommitted changes), e.g. `6ee40f2`.
 //!   * `CELO_KONA_GIT_SHA_LONG`  — full 40-char SHA.
 
 use std::{env, process::Command};

--- a/crates/celo-reth/build.rs
+++ b/crates/celo-reth/build.rs
@@ -1,0 +1,72 @@
+//! Build script that records the celo-kona git SHA so `celo-reth --version` can show
+//! it alongside the upstream reth commit.
+//!
+//! Resolution order (first hit wins):
+//!   1. `CELO_KONA_GIT_SHA` env var passed by the build environment (Docker build-arg or
+//!      explicit shell override). This is the path Docker/CI builds use, because
+//!      `.dockerignore` excludes `.git/` and the in-container source has no git repo.
+//!   2. `git rev-parse HEAD` against the workspace. Works for local `cargo build`
+//!      invocations where `.git/` is on disk.
+//!   3. The literal string `"unknown"`, with a build warning.
+//!
+//! Output env vars (set via `cargo:rustc-env`):
+//!   * `CELO_KONA_GIT_SHA`       — 7-char short SHA (with optional `-dirty` suffix
+//!                                  when git reports uncommitted changes), e.g. `6ee40f2`.
+//!   * `CELO_KONA_GIT_SHA_LONG`  — full 40-char SHA.
+
+use std::{env, process::Command};
+
+fn main() {
+    let (sha_long, dirty) = resolve_sha();
+    let sha_short = sha_long.get(..7).unwrap_or(sha_long.as_str()).to_string();
+    let sha_display = if dirty { format!("{sha_short}-dirty") } else { sha_short };
+
+    println!("cargo:rustc-env=CELO_KONA_GIT_SHA_LONG={sha_long}");
+    println!("cargo:rustc-env=CELO_KONA_GIT_SHA={sha_display}");
+
+    // Re-run when the env override or the local HEAD/refs change. Best-effort: these
+    // paths only exist for local cargo builds; Docker builds rely on the env var.
+    println!("cargo:rerun-if-env-changed=CELO_KONA_GIT_SHA");
+    for p in [".git/HEAD", ".git/refs/heads", ".git/packed-refs"] {
+        println!("cargo:rerun-if-changed=../../{p}");
+    }
+}
+
+fn resolve_sha() -> (String, bool) {
+    if let Ok(s) = env::var("CELO_KONA_GIT_SHA") {
+        let s = s.trim().to_string();
+        if !s.is_empty() && s != "unknown" {
+            return (s, false);
+        }
+    }
+
+    if let Some((sha, dirty)) = git_head_sha() {
+        return (sha, dirty);
+    }
+
+    println!(
+        "cargo:warning=celo-reth build.rs: CELO_KONA_GIT_SHA not set and `git rev-parse HEAD` \
+         failed; --version will report `unknown`. Set CELO_KONA_GIT_SHA at build time to fix."
+    );
+    ("unknown".to_string(), false)
+}
+
+/// Returns `(sha, is_dirty)` if `git` resolves the workspace HEAD, else `None`.
+fn git_head_sha() -> Option<(String, bool)> {
+    let head = Command::new("git").args(["rev-parse", "HEAD"]).output().ok()?;
+    if !head.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(head.stdout).ok()?.trim().to_string();
+    if sha.is_empty() {
+        return None;
+    }
+    // `--porcelain` is empty iff the working tree is clean.
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+    Some((sha, dirty))
+}

--- a/crates/celo-reth/build.rs
+++ b/crates/celo-reth/build.rs
@@ -24,12 +24,10 @@ fn main() {
     println!("cargo:rustc-env=CELO_KONA_GIT_SHA_LONG={sha_long}");
     println!("cargo:rustc-env=CELO_KONA_GIT_SHA={sha_display}");
 
-    // Re-run when the env override or the local HEAD/refs change. Best-effort: these
-    // paths only exist for local cargo builds; Docker builds rely on the env var.
+    // Do not add `cargo:rerun-if-changed=<path>` here: emitting any path directive
+    // disables Cargo's default package-wide change detection and lets the `-dirty`
+    // flag go stale on local edits. Env-changed alone is enough.
     println!("cargo:rerun-if-env-changed=CELO_KONA_GIT_SHA");
-    for p in [".git/HEAD", ".git/refs/heads", ".git/packed-refs"] {
-        println!("cargo:rerun-if-changed=../../{p}");
-    }
 }
 
 fn resolve_sha() -> (String, bool) {

--- a/crates/celo-reth/build.rs
+++ b/crates/celo-reth/build.rs
@@ -24,10 +24,14 @@ fn main() {
     println!("cargo:rustc-env=CELO_KONA_GIT_SHA_LONG={sha_long}");
     println!("cargo:rustc-env=CELO_KONA_GIT_SHA={sha_display}");
 
-    // Do not add `cargo:rerun-if-changed=<path>` here: emitting any path directive
-    // disables Cargo's default package-wide change detection and lets the `-dirty`
-    // flag go stale on local edits. Env-changed alone is enough.
+    // Any `rerun-if` directive (env or path) disables Cargo's default package-wide
+    // scan, so the env watch below already opts us out of it. Watch git metadata to
+    // re-run on commits/branch switches; a stale `-dirty` flag on uncommitted edits
+    // is a known best-effort limitation. CI is unaffected (env var path).
     println!("cargo:rerun-if-env-changed=CELO_KONA_GIT_SHA");
+    for p in [".git/HEAD", ".git/refs/heads", ".git/packed-refs"] {
+        println!("cargo:rerun-if-changed=../../{p}");
+    }
 }
 
 fn resolve_sha() -> (String, bool) {

--- a/crates/celo-reth/src/bin/celo_reth.rs
+++ b/crates/celo-reth/src/bin/celo_reth.rs
@@ -25,7 +25,10 @@ use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
 use reth_db_api::database_metrics::DatabaseMetrics;
 use reth_node_builder::{NodeBuilder, WithLaunchContext};
-use reth_node_core::args::{LogArgs, OtlpInitStatus, OtlpLogsStatus, TraceArgs};
+use reth_node_core::{
+    args::{LogArgs, OtlpInitStatus, OtlpLogsStatus, TraceArgs},
+    version::{default_reth_version_metadata, try_init_version_metadata},
+};
 use reth_node_metrics::recorder::install_prometheus_recorder;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_cli::Cli;
@@ -190,7 +193,31 @@ pub struct CeloArgs {
     pub fee_currency_default: f64,
 }
 
+/// Augment reth's version metadata with the celo-kona git SHA so `celo-reth --version` shows
+/// both the upstream reth commit and the celo-kona commit that built the binary.
+///
+/// Must run before any clap command building that surfaces `--version`. The underlying global
+/// is a [`OnceLock`], so the first call wins; we ignore the `Err` (already-set) case for safety
+/// in tests or other entry points.
+///
+/// `CELO_KONA_GIT_SHA` / `CELO_KONA_GIT_SHA_LONG` are injected at compile time by
+/// `crates/celo-reth/build.rs` from either the `CELO_KONA_GIT_SHA` build env (Docker build-arg
+/// path) or `git rev-parse HEAD` (local cargo build path).
+fn init_celo_version_metadata() {
+    let mut meta = default_reth_version_metadata();
+    let celo_sha = env!("CELO_KONA_GIT_SHA");
+    let celo_sha_long = env!("CELO_KONA_GIT_SHA_LONG");
+    // `short_version` is what reth's clap renders for `--version`. Keep reth's existing string
+    // (which already includes reth's short SHA + build profile) and append the celo-kona SHA.
+    meta.short_version = format!("{} / celo-kona {}", meta.short_version, celo_sha).into();
+    // `long_version` is the multi-line output for `--version --verbose` style consumers.
+    meta.long_version =
+        format!("{}\nCelo-Kona Commit SHA: {}", meta.long_version, celo_sha_long).into();
+    let _ = try_init_version_metadata(meta);
+}
+
 fn main() {
+    init_celo_version_metadata();
     reth_cli_util::sigsegv_handler::install();
 
     if std::env::var_os("RUST_BACKTRACE").is_none() {


### PR DESCRIPTION
## Summary

`celo-reth --version` currently reports only the upstream paradigmxyz/reth commit SHA (e.g. `7680d6d8…`). That makes it impossible to tell which celo-kona build a running binary came from without cross-referencing the image tag or git history — a real pain when triaging migrations, snapshots, or production incidents.

This PR augments reth's existing version metadata so the binary also surfaces the celo-kona commit:

```
Reth Version: 2.2.0-dev
Commit SHA: 7680d6d8a931c0af4f4eed26e971596970238b54
Build Timestamp: 2026-06-10T10:44:20Z
Build Profile: release
Celo-Kona Commit SHA: 087a329a09b9be6cb647ee1eb1d6f9fd55028c47
```

## How it works

| File | Change |
|---|---|
| `crates/celo-reth/build.rs` (new) | Exports `CELO_KONA_GIT_SHA` / `CELO_KONA_GIT_SHA_LONG` env vars at compile time. Resolution order: (1) `CELO_KONA_GIT_SHA` build env (Docker build-arg path), (2) `git rev-parse HEAD` (local cargo build path), (3) literal `unknown` with a build warning. |
| `crates/celo-reth/src/bin/celo_reth.rs` | Adds `init_celo_version_metadata()` called as the first line of `main()`. Overrides reth's global `RethCliVersionConsts` via `try_init_version_metadata`, appending the celo-kona SHA to `short_version` and `long_version` only. `vergen_git_sha`, `p2p_client_version`, and the DB `ClientVersion` (all reth-side machine-readable fields) are intentionally left untouched. |
| `crates/celo-reth/Dockerfile` | Accepts `CELO_KONA_GIT_SHA` as an `ARG` and propagates via `ENV` so the in-container build.rs sees it. Defaults to `unknown` so plain `docker build` without the arg still succeeds. |
| `.github/workflows/push-container-dev.yaml` | Passes `CELO_KONA_GIT_SHA=${{ github.event.pull_request.head.sha \|\| github.sha }}` via the reusable workflow's `build-args` input. |

`.dockerignore` excludes `.git/`, so the build-arg path is the only way the SHA reaches the in-container build — handled by the Dockerfile + workflow changes above.

## Test plan

- [x] `cargo build -p celo-reth` succeeds locally
- [x] Local `./target/debug/celo-reth --version` shows the workspace HEAD SHA (`087a329…`) as the celo-kona commit, with reth's `7680d6d8…` still present (verified)
- [x] No reth-side machine-readable version fields changed (`vergen_git_sha`, P2P client string, DB `ClientVersion`)
- [ ] CI: PR build of `celo-kona-reth:pr-XXX` produces an image whose `celo-reth --version` shows the PR head SHA (gates merge)

## Notes

- The reusable workflow (`celo-org/reusable-workflows@v3.1`) already exposes `build-args` — no infra change needed there.
- Local cargo builds without the env var set fall back to `git rev-parse HEAD`, so dev builds Just Work without manual flags.
- If `.git/` is ever stripped from a local build context too (e.g. for a sandboxed sysroot build), the output gracefully degrades to `Celo-Kona Commit SHA: unknown` with a `cargo:warning` rather than failing the build.
