### PR TITLE
fix(celo-revm): quiet the unknown-chain-id address fallback log

### DIFF
--- a/crates/celo-revm/src/constants.rs
+++ b/crates/celo-revm/src/constants.rs
@@ -54,18 +54,21 @@ lazy_static! {
     };
 }
 
-/// Returns the addresses for the given chain ID, or Celo Mainnet addresses if not found.
+/// Returns the addresses for the given chain ID, falling back to Celo Mainnet's
+/// addresses if the chain is not in the table.
 ///
-/// Logs a warning for unknown chain IDs since the Celo Mainnet addresses are almost
-/// certainly wrong on other chains and will cause fee debit/credit to target
-/// non-existent or incorrect contracts.
+/// The fallback mirrors op-geth's `GetAddressesOrDefault(chainID, MainnetAddresses)`
+/// and is correct for chains that reuse Mainnet's deterministic system-contract
+/// addresses (e.g. dev and internal testnets). It is only wrong on a chain whose
+/// addresses genuinely differ, so the miss is logged at `debug` rather than `warn`.
 pub fn get_addresses(chain_id: u64) -> &'static CeloAddresses {
     CELO_ADDRESSES.get(&chain_id).unwrap_or_else(|| {
-        tracing::warn!(
+        tracing::debug!(
             target: "celo::constants",
             chain_id,
-            "Unknown chain ID — falling back to Celo Mainnet contract addresses. \
-             Fee currency operations will likely fail on this chain."
+            "chain ID not in the known address table; using Celo Mainnet \
+             system-contract addresses (correct for chains that reuse Mainnet's \
+             deterministic addresses, e.g. dev/internal testnets)"
         );
         &CELO_ADDRESSES[&CELO_MAINNET_CHAIN_ID]
     })


### PR DESCRIPTION
## Background

`get_addresses` falls back to Celo Mainnet's system-contract addresses for any chain ID not in the table, mirroring op-geth's [`GetAddressesOrDefault(chainID, MainnetAddresses)`](https://github.com/celo-org/op-geth/blob/6d8cea094b6a4081090f91604795976e86603645/contracts/addresses/addresses.go#L49-L55). op-geth does this silently; we additionally emitted a `warn!` saying "fee currency operations will likely fail on this chain".

That warning is a false alarm on every chain that reuses Mainnet's deterministic addresses: the local dev chain (1337) and our internal testnet (11162320) both resolve `FeeCurrencyDirectory` to the Mainnet address `0x15F344…`, so the fallback is correct and fee currency works. The warning only fires correctly on a chain whose addresses genuinely differ.

## Change

Downgrade the log from `warn!` to `debug!` and reword it so normal logs stay quiet (matching op-geth) while a breadcrumb remains for diagnosing a chain that genuinely needs its own table entry. Behavior is otherwise unchanged.
